### PR TITLE
feat: add settings icon to channel items

### DIFF
--- a/apps/harmonie/src/features/channel/ChannelSection.tsx
+++ b/apps/harmonie/src/features/channel/ChannelSection.tsx
@@ -20,6 +20,8 @@ interface SortableChannelItemProps {
   canReorder: boolean;
   onNavigate: () => void;
   onContextMenu?: (e: React.MouseEvent) => void;
+  onMenuClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  menuLabel?: string;
 }
 
 const SortableChannelItem = ({
@@ -28,6 +30,8 @@ const SortableChannelItem = ({
   canReorder,
   onNavigate,
   onContextMenu,
+  onMenuClick,
+  menuLabel,
 }: SortableChannelItemProps) => {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: channel.channelId,
@@ -53,6 +57,8 @@ const SortableChannelItem = ({
         active={active}
         onClick={onNavigate}
         onContextMenu={onContextMenu}
+        onMenuClick={onMenuClick}
+        menuLabel={menuLabel}
       />
     </div>
   );
@@ -63,6 +69,8 @@ interface ChannelSectionProps {
   type: 'Text' | 'Voice';
   canReorder: boolean;
   onContextMenu?: (e: React.MouseEvent, channel: Channel) => void;
+  onMenuClick?: (e: React.MouseEvent<HTMLButtonElement>, channel: Channel) => void;
+  menuLabel?: string;
 }
 
 export const ChannelSection = ({
@@ -70,6 +78,8 @@ export const ChannelSection = ({
   type,
   canReorder,
   onContextMenu,
+  onMenuClick,
+  menuLabel,
 }: ChannelSectionProps) => {
   const { guildId, channelId: activeChannelId } = useParams<{
     guildId: string;
@@ -127,6 +137,8 @@ export const ChannelSection = ({
                 )
               }
               onContextMenu={onContextMenu ? (e) => onContextMenu(e, channel) : undefined}
+              onMenuClick={onMenuClick ? (e) => onMenuClick(e, channel) : undefined}
+              menuLabel={menuLabel}
             />
           ))}
         </div>

--- a/apps/harmonie/src/features/channel/ChannelSidebar.tsx
+++ b/apps/harmonie/src/features/channel/ChannelSidebar.tsx
@@ -17,6 +17,7 @@ type CreateModalState = { type: 'Text' | 'Voice' } | null;
 type ContextMenuState = {
   channel: Channel;
   position: { x: number; y: number };
+  horizontalAnchor?: 'left' | 'right';
 } | null;
 type EditModalState = {
   channel: Channel;
@@ -32,7 +33,7 @@ export const ChannelSidebar = () => {
   const navigate = useNavigate();
   const { guilds } = useGuilds();
   const guild = guilds.find((g) => g.guildId === guildId) ?? null;
-  const { isAdmin, canManageChannels, canManageGuild } = useGuildPermissions(guild);
+  const { canManageChannels, canManageGuild } = useGuildPermissions(guild);
   const canReorder = canManageChannels;
   const { channels, addChannel, updateChannel, removeChannel } = useChannels();
   const { fetchGuilds } = useGuilds();
@@ -62,6 +63,10 @@ export const ChannelSidebar = () => {
   const handleContextMenu = (e: React.MouseEvent, channel: Channel) => {
     e.preventDefault();
     setContextMenu({ channel, position: { x: e.clientX, y: e.clientY } });
+  };
+
+  const handleMenuButtonClick = (_e: React.MouseEvent<HTMLButtonElement>, channel: Channel) => {
+    openEdit(channel, 'rename');
   };
 
   const openEdit = (channel: Channel, section: EditChannelSection) => {
@@ -105,7 +110,7 @@ export const ChannelSidebar = () => {
   return (
     <>
       <aside className="flex flex-col w-60 bg-surface-1 rounded-sm shrink-0 border border-border-2">
-        <header className="px-4 py-3 border-b border-border-2 bg-surface-2 rounded-t-sm flex items-center justify-between gap-2">
+        <header className="pl-4 pr-2 py-3 border-b border-border-2 bg-surface-2 rounded-t-sm flex items-center justify-between gap-2">
           <h2 className="font-semibold text-text-1 truncate">{guild?.name ?? guildId}</h2>
           {canManageGuild && guild && (
             <IconButton
@@ -144,7 +149,7 @@ export const ChannelSidebar = () => {
                   <p className="text-xs font-semibold uppercase tracking-wide px-2">
                     {t('guild.channels.text')}
                   </p>
-                  {isAdmin && (
+                  {canManageChannels && (
                     <IconButton
                       size="small"
                       variant="ghost"
@@ -158,7 +163,9 @@ export const ChannelSidebar = () => {
                   sectionChannels={textChannels}
                   type="Text"
                   canReorder={canReorder}
-                  onContextMenu={isAdmin ? handleContextMenu : undefined}
+                  onContextMenu={canManageChannels ? handleContextMenu : undefined}
+                  onMenuClick={canManageChannels ? handleMenuButtonClick : undefined}
+                  menuLabel={t('guild.channels.edit.title')}
                 />
               </section>
 
@@ -168,7 +175,7 @@ export const ChannelSidebar = () => {
                   <p className="text-xs font-semibold uppercase tracking-wide px-2">
                     {t('guild.channels.voice')}
                   </p>
-                  {isAdmin && (
+                  {canManageChannels && (
                     <IconButton
                       size="small"
                       variant="ghost"
@@ -182,7 +189,9 @@ export const ChannelSidebar = () => {
                   sectionChannels={voiceChannels}
                   type="Voice"
                   canReorder={canReorder}
-                  onContextMenu={isAdmin ? handleContextMenu : undefined}
+                  onContextMenu={canManageChannels ? handleContextMenu : undefined}
+                  onMenuClick={canManageChannels ? handleMenuButtonClick : undefined}
+                  menuLabel={t('guild.channels.edit.title')}
                 />
               </section>
             </>
@@ -199,6 +208,7 @@ export const ChannelSidebar = () => {
           position={contextMenu.position}
           onClose={() => setContextMenu(null)}
           items={buildContextMenuItems(contextMenu.channel)}
+          horizontalAnchor={contextMenu.horizontalAnchor}
         />
       )}
 

--- a/packages/ui/src/components/ChannelItem/ChannelItem.tsx
+++ b/packages/ui/src/components/ChannelItem/ChannelItem.tsx
@@ -1,4 +1,5 @@
-import { Hash, Volume2 } from 'lucide-react';
+import { Hash, Settings, Volume2 } from 'lucide-react';
+import { IconButton } from '../IconButton/IconButton';
 
 export type ChannelType = 'text' | 'voice';
 
@@ -8,6 +9,8 @@ export interface ChannelItemProps {
   active?: boolean;
   onClick: () => void;
   onContextMenu?: (e: React.MouseEvent) => void;
+  onMenuClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  menuLabel?: string;
 }
 
 export const ChannelItem = ({
@@ -16,22 +19,47 @@ export const ChannelItem = ({
   active = false,
   onClick,
   onContextMenu,
+  onMenuClick,
+  menuLabel,
 }: ChannelItemProps) => {
   const Icon = type === 'text' ? Hash : Volume2;
+  const baseStateClasses = active
+    ? 'bg-surface-2 text-text-1 font-medium'
+    : 'text-text-2 hover:bg-surface-2 hover:text-text-1 hover:bg-opacity-70';
 
   return (
-    <button
-      onClick={onClick}
-      onContextMenu={onContextMenu}
-      className={[
-        'flex items-center gap-2 w-full px-2 py-1 rounded-sm text-sm font-body transition-colors text-left cursor-pointer',
-        active
-          ? 'bg-surface-2 text-text-1 font-medium'
-          : 'text-text-2 hover:bg-surface-2 hover:text-text-1 hover:bg-opacity-70',
-      ].join(' ')}
-    >
-      <Icon size={16} className="shrink-0 text-text-3" />
-      <span className="truncate">{label}</span>
-    </button>
+    <div className={['group flex items-center gap-1 rounded-sm', baseStateClasses].join(' ')}>
+      <button
+        onClick={onClick}
+        onContextMenu={onContextMenu}
+        className="flex min-w-0 flex-1 items-center gap-2 px-2 py-1 text-sm font-body transition-colors text-left cursor-pointer"
+      >
+        <Icon size={16} className="shrink-0 text-text-3" />
+        <span className="truncate">{label}</span>
+      </button>
+
+      {onMenuClick && (
+        <IconButton
+          size="small"
+          variant="overlay"
+          aria-label={menuLabel}
+          title={menuLabel}
+          onClick={(e) => {
+            e.stopPropagation();
+            onMenuClick(e);
+          }}
+          onMouseDown={(e) => e.stopPropagation()}
+          className={[
+            'shrink-0 basis-7 min-w-7 min-h-7 transition-all',
+            'opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto focus:opacity-100 focus:pointer-events-auto',
+            active
+              ? 'text-text-2 hover:bg-surface-3'
+              : 'text-text-3 hover:bg-surface-2 hover:text-text-1',
+          ].join(' ')}
+        >
+          <Settings size={14} className="shrink-0" />
+        </IconButton>
+      )}
+    </div>
   );
 };


### PR DESCRIPTION
- Add a settings (gear) icon to channel items that appears on hover for users with channel management permissions
- Update sidebar permission logic to use `canManageChannels` instead of a strict `isAdmin` check
- Allow quick access to channel settings/renaming via the new inline menu button