### PR TITLE
feat: Docker deployment setup

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ node_modules
 storybook-static
 pnpm-lock.yaml
 mockups
+docker*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:22-alpine AS builder
+RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
+WORKDIR /app
+
+# Install deps first (cache layer)
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY apps/harmonie/package.json ./apps/harmonie/
+COPY packages/ui/package.json ./packages/ui/
+RUN pnpm install --frozen-lockfile
+
+# Build
+COPY . .
+ARG VITE_API_BASE_URL
+ARG VITE_WS_BASE_URL
+RUN pnpm build
+
+FROM node:22-alpine AS runner
+WORKDIR /app
+COPY --from=builder /app/apps/harmonie/dist ./dist
+COPY docker/server.js ./server.js
+ENV PORT=80
+EXPOSE 80
+CMD ["node", "server.js"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  harmonie:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+      args:
+        VITE_API_BASE_URL: http://192.168.1.67:55401/api
+        VITE_WS_BASE_URL: http://192.168.1.67:55401/hubs/realtime
+    ports:
+      - "3757:80"
+    restart: unless-stopped

--- a/docker/server.js
+++ b/docker/server.js
@@ -1,0 +1,41 @@
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DIST = path.join(__dirname, 'dist');
+const PORT = process.env.PORT || 80;
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript',
+  '.css': 'text/css',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.json': 'application/json',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.webp': 'image/webp',
+};
+
+http
+  .createServer((req, res) => {
+    const url = req.url.split('?')[0];
+    let filePath = path.join(DIST, url === '/' ? 'index.html' : url);
+    const ext = path.extname(filePath);
+
+    if (!ext || !fs.existsSync(filePath)) {
+      filePath = path.join(DIST, 'index.html');
+    }
+
+    const mime = MIME[path.extname(filePath)] || 'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': mime });
+    fs.createReadStream(filePath).pipe(res);
+  })
+  .listen(PORT, () => console.log(`Harmonie listening on :${PORT}`));


### PR DESCRIPTION
## Summary

- Ajout d'un `Dockerfile` multi-stage : build du monorepo pnpm puis image Alpine légère
- Ajout d'un `docker-compose.yml` avec les variables de build et le port configurés en dur
- Ajout d'un serveur Node.js minimal (`server.js`) pour servir les assets statiques avec fallback SPA

Tous les fichiers sont dans `docker/`.