### PR TITLE
fix: keep SignalR connected across token expiration

### DIFF
--- a/apps/harmonie/src/api/authStorage.test.ts
+++ b/apps/harmonie/src/api/authStorage.test.ts
@@ -8,48 +8,79 @@ import {
   subscribeToTokenChanges,
 } from './authStorage';
 
+const FUTURE_EXPIRATION = '2100-01-01T00:00:00.000Z';
+
 describe('authStorage', () => {
   beforeEach(() => {
     clearTokens();
   });
 
-  it('stores the access token in memory and the refresh token in localStorage', () => {
-    storeTokens({ accessToken: 'access-token', refreshToken: 'refresh-token' });
+  it('stores the access token and its expiration in memory and the refresh token in localStorage', () => {
+    storeTokens({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: FUTURE_EXPIRATION,
+    });
 
     expect(getAccessToken()).toBe('access-token');
+    expect(isAccessTokenExpiring()).toBe(false);
     expect(getRefreshToken()).toBe('refresh-token');
     expect(localStorage.getItem('refreshToken')).toBe('refresh-token');
   });
 
-  it('clears both tokens', () => {
-    storeTokens({ accessToken: 'access-token', refreshToken: 'refresh-token' });
+  it('clears both tokens and the access token expiration', () => {
+    storeTokens({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: FUTURE_EXPIRATION,
+    });
 
     clearTokens();
 
     expect(getAccessToken()).toBeNull();
+    expect(isAccessTokenExpiring()).toBe(true);
     expect(getRefreshToken()).toBeNull();
   });
 
   it('detects access tokens that are expired or close to expiry', () => {
-    const accessToken = `header.${btoa(JSON.stringify({ exp: 130 }))}.signature`;
+    storeTokens({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: '1970-01-01T00:02:10.000Z',
+    });
 
-    expect(isAccessTokenExpiring(accessToken, 30_000, 100_000)).toBe(true);
-    expect(isAccessTokenExpiring(accessToken, 29_000, 100_000)).toBe(false);
+    expect(isAccessTokenExpiring(30_000, 100_000)).toBe(true);
+    expect(isAccessTokenExpiring(29_000, 100_000)).toBe(false);
   });
 
-  it('treats opaque or malformed access tokens as unusable', () => {
-    expect(isAccessTokenExpiring('opaque-token')).toBe(true);
-    expect(isAccessTokenExpiring('header.not-json.signature')).toBe(true);
+  it('treats a missing or invalid expiration as unusable', () => {
+    expect(isAccessTokenExpiring()).toBe(true);
+
+    storeTokens({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: 'invalid-date',
+    });
+
+    expect(isAccessTokenExpiring()).toBe(true);
   });
 
   it('notifies subscribers when tokens change', () => {
     const listener = vi.fn();
     const unsubscribe = subscribeToTokenChanges(listener);
 
-    storeTokens({ accessToken: 'access-token', refreshToken: 'refresh-token' });
+    storeTokens({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: FUTURE_EXPIRATION,
+    });
     clearTokens();
     unsubscribe();
-    storeTokens({ accessToken: 'next-token', refreshToken: 'next-refresh-token' });
+    storeTokens({
+      accessToken: 'next-token',
+      refreshToken: 'next-refresh-token',
+      expiresAt: FUTURE_EXPIRATION,
+    });
 
     expect(listener).toHaveBeenNthCalledWith(1, 'access-token');
     expect(listener).toHaveBeenNthCalledWith(2, null);

--- a/apps/harmonie/src/api/authStorage.test.ts
+++ b/apps/harmonie/src/api/authStorage.test.ts
@@ -3,6 +3,7 @@ import {
   clearTokens,
   getAccessToken,
   getRefreshToken,
+  isAccessTokenExpiring,
   storeTokens,
   subscribeToTokenChanges,
 } from './authStorage';
@@ -27,6 +28,18 @@ describe('authStorage', () => {
 
     expect(getAccessToken()).toBeNull();
     expect(getRefreshToken()).toBeNull();
+  });
+
+  it('detects access tokens that are expired or close to expiry', () => {
+    const accessToken = `header.${btoa(JSON.stringify({ exp: 130 }))}.signature`;
+
+    expect(isAccessTokenExpiring(accessToken, 30_000, 100_000)).toBe(true);
+    expect(isAccessTokenExpiring(accessToken, 29_000, 100_000)).toBe(false);
+  });
+
+  it('treats opaque or malformed access tokens as unusable', () => {
+    expect(isAccessTokenExpiring('opaque-token')).toBe(true);
+    expect(isAccessTokenExpiring('header.not-json.signature')).toBe(true);
   });
 
   it('notifies subscribers when tokens change', () => {

--- a/apps/harmonie/src/api/authStorage.ts
+++ b/apps/harmonie/src/api/authStorage.ts
@@ -17,6 +17,23 @@ export const storeTokens = (response: TokensPayload) => {
 
 export const getAccessToken = () => _accessToken;
 
+export const isAccessTokenExpiring = (
+  accessToken: string,
+  expirationBufferMs = 30_000,
+  now = Date.now()
+) => {
+  try {
+    const payload = accessToken.split('.')[1];
+    if (!payload) return true;
+
+    const normalizedPayload = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const { exp } = JSON.parse(atob(normalizedPayload)) as { exp?: number };
+    return typeof exp !== 'number' || exp * 1000 <= now + expirationBufferMs;
+  } catch {
+    return true;
+  }
+};
+
 export const getRefreshToken = () => localStorage.getItem(REFRESH_TOKEN_KEY);
 
 export const subscribeToTokenChanges = (listener: (accessToken: string | null) => void) => {

--- a/apps/harmonie/src/api/authStorage.ts
+++ b/apps/harmonie/src/api/authStorage.ts
@@ -1,8 +1,10 @@
 import type { TokensPayload } from '@/types/auth';
 
 const REFRESH_TOKEN_KEY = 'refreshToken';
+const ACCESS_TOKEN_EXPIRATION_BUFFER_MS = 30_000;
 
 let _accessToken: string | null = null;
+let _accessTokenExpiresAt: number | null = null;
 const tokenChangeListeners = new Set<(accessToken: string | null) => void>();
 
 const notifyTokenChange = () => {
@@ -11,6 +13,7 @@ const notifyTokenChange = () => {
 
 export const storeTokens = (response: TokensPayload) => {
   _accessToken = response.accessToken;
+  _accessTokenExpiresAt = Date.parse(response.expiresAt);
   localStorage.setItem(REFRESH_TOKEN_KEY, response.refreshToken);
   notifyTokenChange();
 };
@@ -18,21 +21,12 @@ export const storeTokens = (response: TokensPayload) => {
 export const getAccessToken = () => _accessToken;
 
 export const isAccessTokenExpiring = (
-  accessToken: string,
-  expirationBufferMs = 30_000,
+  expirationBufferMs = ACCESS_TOKEN_EXPIRATION_BUFFER_MS,
   now = Date.now()
-) => {
-  try {
-    const payload = accessToken.split('.')[1];
-    if (!payload) return true;
-
-    const normalizedPayload = payload.replace(/-/g, '+').replace(/_/g, '/');
-    const { exp } = JSON.parse(atob(normalizedPayload)) as { exp?: number };
-    return typeof exp !== 'number' || exp * 1000 <= now + expirationBufferMs;
-  } catch {
-    return true;
-  }
-};
+) =>
+  _accessTokenExpiresAt === null ||
+  !Number.isFinite(_accessTokenExpiresAt) ||
+  _accessTokenExpiresAt <= now + expirationBufferMs;
 
 export const getRefreshToken = () => localStorage.getItem(REFRESH_TOKEN_KEY);
 
@@ -45,6 +39,7 @@ export const subscribeToTokenChanges = (listener: (accessToken: string | null) =
 
 export const clearTokens = () => {
   _accessToken = null;
+  _accessTokenExpiresAt = null;
   localStorage.removeItem(REFRESH_TOKEN_KEY);
   notifyTokenChange();
 };

--- a/apps/harmonie/src/api/client.test.ts
+++ b/apps/harmonie/src/api/client.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { clearTokens, getAccessToken, getRefreshToken, storeTokens } from './authStorage';
 
 const refreshTokensMock = vi.fn();
+const FUTURE_EXPIRATION = '2100-01-01T00:00:00.000Z';
+const PAST_EXPIRATION = '2000-01-01T00:00:00.000Z';
 
 vi.mock('./auth', () => ({
   refreshTokens: refreshTokensMock,
@@ -17,7 +19,11 @@ describe('apiFetch', () => {
   it('adds the current access token to requests', async () => {
     const fetchMock = vi.mocked(fetch);
     fetchMock.mockResolvedValueOnce(new Response('{}', { status: 200 }));
-    storeTokens({ accessToken: 'access-token', refreshToken: 'refresh-token' });
+    storeTokens({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: FUTURE_EXPIRATION,
+    });
     const { apiFetch } = await import('./client');
 
     await apiFetch('/guilds', { headers: { 'X-Trace': 'trace-id' } });
@@ -38,8 +44,13 @@ describe('apiFetch', () => {
     refreshTokensMock.mockResolvedValueOnce({
       accessToken: 'new-access-token',
       refreshToken: 'new-refresh-token',
+      expiresAt: FUTURE_EXPIRATION,
     });
-    storeTokens({ accessToken: 'old-access-token', refreshToken: 'refresh-token' });
+    storeTokens({
+      accessToken: 'old-access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: FUTURE_EXPIRATION,
+    });
     const { apiFetch } = await import('./client');
 
     const response = await apiFetch('/channels');
@@ -56,21 +67,28 @@ describe('apiFetch', () => {
   });
 
   it('returns the cached access token while it is still valid', async () => {
-    const validToken = `header.${btoa(JSON.stringify({ exp: 4_102_444_800 }))}.signature`;
-    storeTokens({ accessToken: validToken, refreshToken: 'refresh-token' });
+    storeTokens({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: FUTURE_EXPIRATION,
+    });
     const { getFreshAccessToken } = await import('./client');
 
-    await expect(getFreshAccessToken()).resolves.toBe(validToken);
+    await expect(getFreshAccessToken()).resolves.toBe('access-token');
     expect(refreshTokensMock).not.toHaveBeenCalled();
   });
 
   it('refreshes an expired access token before returning it to SignalR', async () => {
-    const expiredToken = `header.${btoa(JSON.stringify({ exp: 1 }))}.signature`;
     refreshTokensMock.mockResolvedValueOnce({
       accessToken: 'fresh-access-token',
       refreshToken: 'fresh-refresh-token',
+      expiresAt: FUTURE_EXPIRATION,
     });
-    storeTokens({ accessToken: expiredToken, refreshToken: 'refresh-token' });
+    storeTokens({
+      accessToken: 'expired-access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: PAST_EXPIRATION,
+    });
     const { getFreshAccessToken } = await import('./client');
 
     await expect(getFreshAccessToken()).resolves.toBe('fresh-access-token');
@@ -79,20 +97,27 @@ describe('apiFetch', () => {
 
   it('deduplicates concurrent refreshes across consumers', async () => {
     let resolveRefresh:
-      | ((tokens: { accessToken: string; refreshToken: string }) => void)
+      | ((tokens: { accessToken: string; refreshToken: string; expiresAt: string }) => void)
       | undefined;
     refreshTokensMock.mockReturnValueOnce(
       new Promise((resolve) => {
         resolveRefresh = resolve;
       })
     );
-    const expiredToken = `header.${btoa(JSON.stringify({ exp: 1 }))}.signature`;
-    storeTokens({ accessToken: expiredToken, refreshToken: 'refresh-token' });
+    storeTokens({
+      accessToken: 'expired-access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: PAST_EXPIRATION,
+    });
     const { getFreshAccessToken, refreshAccessToken } = await import('./client');
 
     const fromSignalR = getFreshAccessToken();
     const fromHttp = refreshAccessToken();
-    resolveRefresh?.({ accessToken: 'fresh-access-token', refreshToken: 'new-refresh-token' });
+    resolveRefresh?.({
+      accessToken: 'fresh-access-token',
+      refreshToken: 'new-refresh-token',
+      expiresAt: FUTURE_EXPIRATION,
+    });
 
     await expect(Promise.all([fromSignalR, fromHttp])).resolves.toEqual([
       'fresh-access-token',
@@ -104,7 +129,11 @@ describe('apiFetch', () => {
   it('does not refresh refresh-token requests', async () => {
     const fetchMock = vi.mocked(fetch);
     fetchMock.mockResolvedValueOnce(new Response('{}', { status: 401 }));
-    storeTokens({ accessToken: 'access-token', refreshToken: 'refresh-token' });
+    storeTokens({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: FUTURE_EXPIRATION,
+    });
     const { apiFetch } = await import('./client');
 
     const response = await apiFetch('/auth/refresh');
@@ -121,7 +150,11 @@ describe('apiFetch', () => {
       .mockResolvedValueOnce(new Response('{}', { status: 401 }))
       .mockResolvedValueOnce(new Response('{}', { status: 401 }));
     refreshTokensMock.mockRejectedValueOnce(new Error('expired'));
-    storeTokens({ accessToken: 'access-token', refreshToken: 'refresh-token' });
+    storeTokens({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: FUTURE_EXPIRATION,
+    });
     const { apiFetch, setLogoutHandler } = await import('./client');
     setLogoutHandler(onLogout);
 

--- a/apps/harmonie/src/api/client.test.ts
+++ b/apps/harmonie/src/api/client.test.ts
@@ -55,6 +55,52 @@ describe('apiFetch', () => {
     expect(getRefreshToken()).toBe('new-refresh-token');
   });
 
+  it('returns the cached access token while it is still valid', async () => {
+    const validToken = `header.${btoa(JSON.stringify({ exp: 4_102_444_800 }))}.signature`;
+    storeTokens({ accessToken: validToken, refreshToken: 'refresh-token' });
+    const { getFreshAccessToken } = await import('./client');
+
+    await expect(getFreshAccessToken()).resolves.toBe(validToken);
+    expect(refreshTokensMock).not.toHaveBeenCalled();
+  });
+
+  it('refreshes an expired access token before returning it to SignalR', async () => {
+    const expiredToken = `header.${btoa(JSON.stringify({ exp: 1 }))}.signature`;
+    refreshTokensMock.mockResolvedValueOnce({
+      accessToken: 'fresh-access-token',
+      refreshToken: 'fresh-refresh-token',
+    });
+    storeTokens({ accessToken: expiredToken, refreshToken: 'refresh-token' });
+    const { getFreshAccessToken } = await import('./client');
+
+    await expect(getFreshAccessToken()).resolves.toBe('fresh-access-token');
+    expect(refreshTokensMock).toHaveBeenCalledOnce();
+  });
+
+  it('deduplicates concurrent refreshes across consumers', async () => {
+    let resolveRefresh:
+      | ((tokens: { accessToken: string; refreshToken: string }) => void)
+      | undefined;
+    refreshTokensMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRefresh = resolve;
+      })
+    );
+    const expiredToken = `header.${btoa(JSON.stringify({ exp: 1 }))}.signature`;
+    storeTokens({ accessToken: expiredToken, refreshToken: 'refresh-token' });
+    const { getFreshAccessToken, refreshAccessToken } = await import('./client');
+
+    const fromSignalR = getFreshAccessToken();
+    const fromHttp = refreshAccessToken();
+    resolveRefresh?.({ accessToken: 'fresh-access-token', refreshToken: 'new-refresh-token' });
+
+    await expect(Promise.all([fromSignalR, fromHttp])).resolves.toEqual([
+      'fresh-access-token',
+      'fresh-access-token',
+    ]);
+    expect(refreshTokensMock).toHaveBeenCalledOnce();
+  });
+
   it('does not refresh refresh-token requests', async () => {
     const fetchMock = vi.mocked(fetch);
     fetchMock.mockResolvedValueOnce(new Response('{}', { status: 401 }));

--- a/apps/harmonie/src/api/client.ts
+++ b/apps/harmonie/src/api/client.ts
@@ -1,8 +1,14 @@
-import { clearTokens, getAccessToken, getRefreshToken, storeTokens } from './authStorage';
+import {
+  clearTokens,
+  getAccessToken,
+  getRefreshToken,
+  isAccessTokenExpiring,
+  storeTokens,
+} from './authStorage';
 import { refreshTokens } from './auth';
 
 let onLogout: (() => void) | null = null;
-let refreshPromise: Promise<void> | null = null;
+let refreshPromise: Promise<string> | null = null;
 
 export const setLogoutHandler = (fn: () => void) => {
   onLogout = fn;
@@ -16,19 +22,40 @@ const withBearer = (init?: RequestInit): RequestInit => ({
   },
 });
 
-const doRefresh = async (): Promise<void> => {
+const doRefresh = async (): Promise<string> => {
   const refreshToken = getRefreshToken();
   if (!refreshToken) {
+    clearTokens();
     onLogout?.();
-    return;
+    throw new Error('No refresh token is available');
   }
+
   try {
     const response = await refreshTokens({ refreshToken });
     storeTokens(response);
-  } catch {
+    return response.accessToken;
+  } catch (error) {
     clearTokens();
     onLogout?.();
+    throw error;
   }
+};
+
+export const refreshAccessToken = (): Promise<string> => {
+  if (!refreshPromise) {
+    refreshPromise = doRefresh().finally(() => {
+      refreshPromise = null;
+    });
+  }
+
+  return refreshPromise;
+};
+
+export const getFreshAccessToken = async (): Promise<string> => {
+  const accessToken = getAccessToken();
+  if (accessToken && !isAccessTokenExpiring(accessToken)) return accessToken;
+
+  return refreshAccessToken();
 };
 
 export const apiFetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
@@ -38,12 +65,11 @@ export const apiFetch = async (input: RequestInfo | URL, init?: RequestInit): Pr
   const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
   if (url.includes('/auth/refresh')) return res;
 
-  if (!refreshPromise) {
-    refreshPromise = doRefresh().finally(() => {
-      refreshPromise = null;
-    });
+  try {
+    await refreshAccessToken();
+  } catch {
+    return res;
   }
-  await refreshPromise;
 
   return fetch(input, withBearer(init));
 };

--- a/apps/harmonie/src/api/client.ts
+++ b/apps/harmonie/src/api/client.ts
@@ -53,7 +53,7 @@ export const refreshAccessToken = (): Promise<string> => {
 
 export const getFreshAccessToken = async (): Promise<string> => {
   const accessToken = getAccessToken();
-  if (accessToken && !isAccessTokenExpiring(accessToken)) return accessToken;
+  if (accessToken && !isAccessTokenExpiring()) return accessToken;
 
   return refreshAccessToken();
 };

--- a/apps/harmonie/src/api/files.test.ts
+++ b/apps/harmonie/src/api/files.test.ts
@@ -19,9 +19,7 @@ describe('files api', () => {
     await expect(
       downloadFileBlob('file / 1').then((fileBlob) => fileBlob.size)
     ).resolves.toBeGreaterThan(0);
-    expect(apiFetchMock).toHaveBeenCalledWith(
-      'https://localhost:5000/api/files/file%20%2F%201'
-    );
+    expect(apiFetchMock).toHaveBeenCalledWith('https://localhost:5000/api/files/file%20%2F%201');
   });
 
   it('throws download errors with the response status', async () => {
@@ -37,12 +35,9 @@ describe('files api', () => {
 
     await deleteFile('file / 1');
 
-    expect(apiFetchMock).toHaveBeenCalledWith(
-      'https://localhost:5000/api/files/file%20%2F%201',
-      {
-        method: 'DELETE',
-      }
-    );
+    expect(apiFetchMock).toHaveBeenCalledWith('https://localhost:5000/api/files/file%20%2F%201', {
+      method: 'DELETE',
+    });
   });
 
   it('uploads files as form data and parses the response', async () => {
@@ -54,9 +49,7 @@ describe('files api', () => {
     });
 
     const init = apiFetchMock.mock.calls[0][1] as RequestInit;
-    expect(apiFetchMock.mock.calls[0][0]).toBe(
-      'https://localhost:5000/api/files/uploads'
-    );
+    expect(apiFetchMock.mock.calls[0][0]).toBe('https://localhost:5000/api/files/uploads');
     expect(init.method).toBe('POST');
     expect(init.body).toBeInstanceOf(FormData);
   });

--- a/apps/harmonie/src/api/guilds.test.ts
+++ b/apps/harmonie/src/api/guilds.test.ts
@@ -89,14 +89,11 @@ describe('guilds api', () => {
     await updateMemberRole('guild-1', 'user-1', { role: 'admin' } as never);
     await transferOwnership('guild-1', 'user-2');
 
-    expect(apiFetchMock).toHaveBeenCalledWith(
-      'https://localhost:5000/api/guilds/guild-1/members'
-    );
+    expect(apiFetchMock).toHaveBeenCalledWith('https://localhost:5000/api/guilds/guild-1/members');
     expect(apiFetchMock).toHaveBeenCalledWith('https://localhost:5000/api/invites/abc');
-    expect(apiFetchMock).toHaveBeenCalledWith(
-      'https://localhost:5000/api/invites/abc/accept',
-      { method: 'POST' }
-    );
+    expect(apiFetchMock).toHaveBeenCalledWith('https://localhost:5000/api/invites/abc/accept', {
+      method: 'POST',
+    });
     expect(apiFetchMock).toHaveBeenCalledWith(
       'https://localhost:5000/api/guilds/guild-1/owner/transfer',
       {

--- a/apps/harmonie/src/api/users.test.ts
+++ b/apps/harmonie/src/api/users.test.ts
@@ -44,9 +44,7 @@ describe('users api', () => {
     await expect(removeAvatarImage()).resolves.toBeUndefined();
 
     const uploadInit = apiFetchMock.mock.calls[0][1] as RequestInit;
-    expect(apiFetchMock.mock.calls[0][0]).toBe(
-      'https://localhost:5000/api/users/me/avatar'
-    );
+    expect(apiFetchMock.mock.calls[0][0]).toBe('https://localhost:5000/api/users/me/avatar');
     expect(uploadInit.method).toBe('PUT');
     expect(uploadInit.body).toBeInstanceOf(FormData);
     expect(apiFetchMock.mock.calls[1][1]).toMatchObject({

--- a/apps/harmonie/src/features/realtime/RealtimeContext.test.tsx
+++ b/apps/harmonie/src/features/realtime/RealtimeContext.test.tsx
@@ -10,7 +10,6 @@ const mocks = vi.hoisted(() => {
     on: vi.fn(),
     off: vi.fn(),
     onclose: vi.fn(),
-    onreconnecting: vi.fn(),
     start: vi.fn(),
     stop: vi.fn(),
     state: 'Connected',
@@ -34,7 +33,6 @@ const mocks = vi.hoisted(() => {
     hub,
     handlers: new Map<string, Handler>(),
     isAuthenticated: false,
-    reconnectingHandler: null as Handler | null,
   };
 });
 
@@ -74,13 +72,11 @@ describe('RealtimeProvider', () => {
     mocks.hub.on.mockReset();
     mocks.hub.off.mockReset();
     mocks.hub.onclose.mockReset();
-    mocks.hub.onreconnecting.mockReset();
     mocks.hub.start.mockReset();
     mocks.hub.stop.mockReset();
     mocks.hub.state = 'Connected';
     mocks.handlers.clear();
     mocks.closeHandler = null;
-    mocks.reconnectingHandler = null;
     mocks.builder.withUrl.mockClear();
     mocks.builder.withAutomaticReconnect.mockClear();
     mocks.builder.configureLogging.mockClear();
@@ -93,9 +89,6 @@ describe('RealtimeProvider', () => {
     });
     mocks.hub.onclose.mockImplementation((handler: Handler) => {
       mocks.closeHandler = handler;
-    });
-    mocks.hub.onreconnecting.mockImplementation((handler: Handler) => {
-      mocks.reconnectingHandler = handler;
     });
     mocks.builder.withUrl.mockReturnValue(mocks.builder);
     mocks.builder.withAutomaticReconnect.mockReturnValue(mocks.builder);
@@ -139,27 +132,7 @@ describe('RealtimeProvider', () => {
     expect(screen.getByTestId('ready')).toHaveTextContent('true');
   });
 
-  it('marks the connection unready while SignalR reconnects', async () => {
-    mocks.isAuthenticated = true;
-    mocks.hub.start.mockResolvedValueOnce(undefined);
-
-    render(
-      <RealtimeProvider>
-        <RealtimeConsumer />
-      </RealtimeProvider>
-    );
-
-    await waitFor(() => expect(screen.getByTestId('connection')).toHaveTextContent('connected'));
-    act(() => mocks.handlers.get(REALTIME_SERVER_EVENTS.ready)?.());
-    expect(screen.getByTestId('ready')).toHaveTextContent('true');
-
-    act(() => mocks.reconnectingHandler?.());
-
-    expect(screen.getByTestId('connection')).toHaveTextContent('connected');
-    expect(screen.getByTestId('ready')).toHaveTextContent('false');
-  });
-
-  it('recreates a terminally closed connection after automatic reconnect is exhausted', async () => {
+  it('hides a terminally closed connection without starting a competing reconnect loop', async () => {
     mocks.isAuthenticated = true;
     mocks.hub.start.mockResolvedValue(undefined);
 
@@ -169,12 +142,14 @@ describe('RealtimeProvider', () => {
       </RealtimeProvider>
     );
 
-    await waitFor(() => expect(mocks.hub.start).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByTestId('connection')).toHaveTextContent('connected'));
 
     act(() => mocks.closeHandler?.());
 
-    await waitFor(() => expect(mocks.hub.start).toHaveBeenCalledTimes(2));
-    expect(mocks.builder.build).toHaveBeenCalledTimes(2);
+    expect(screen.getByTestId('connection')).toHaveTextContent('none');
+    expect(screen.getByTestId('ready')).toHaveTextContent('false');
+    expect(mocks.hub.start).toHaveBeenCalledOnce();
+    expect(mocks.builder.build).toHaveBeenCalledOnce();
   });
 
   it('removes handlers and stops an active hub on unmount', async () => {

--- a/apps/harmonie/src/features/realtime/RealtimeContext.test.tsx
+++ b/apps/harmonie/src/features/realtime/RealtimeContext.test.tsx
@@ -4,12 +4,13 @@ import { RealtimeProvider, useRealtime } from './RealtimeContext';
 import { REALTIME_SERVER_EVENTS } from './constants';
 
 type Handler = () => void;
-type TokenChangeListener = (accessToken: string | null) => void;
 
 const mocks = vi.hoisted(() => {
   const hub = {
     on: vi.fn(),
     off: vi.fn(),
+    onclose: vi.fn(),
+    onreconnecting: vi.fn(),
     start: vi.fn(),
     stop: vi.fn(),
     state: 'Connected',
@@ -28,12 +29,12 @@ const mocks = vi.hoisted(() => {
 
   return {
     builder,
-    getAccessToken: vi.fn(),
+    closeHandler: null as Handler | null,
+    getFreshAccessToken: vi.fn(),
     hub,
     handlers: new Map<string, Handler>(),
     isAuthenticated: false,
-    subscribeToTokenChanges: vi.fn(),
-    tokenListeners: new Set<TokenChangeListener>(),
+    reconnectingHandler: null as Handler | null,
   };
 });
 
@@ -47,9 +48,8 @@ vi.mock('@microsoft/signalr', () => ({
   },
 }));
 
-vi.mock('@/api/authStorage', () => ({
-  getAccessToken: mocks.getAccessToken,
-  subscribeToTokenChanges: mocks.subscribeToTokenChanges,
+vi.mock('@/api/client', () => ({
+  getFreshAccessToken: mocks.getFreshAccessToken,
 }));
 
 vi.mock('@/features/auth/AuthContext', () => ({
@@ -70,15 +70,17 @@ const RealtimeConsumer = () => {
 describe('RealtimeProvider', () => {
   beforeEach(() => {
     mocks.isAuthenticated = false;
-    mocks.getAccessToken.mockReset();
-    mocks.subscribeToTokenChanges.mockReset();
+    mocks.getFreshAccessToken.mockReset();
     mocks.hub.on.mockReset();
     mocks.hub.off.mockReset();
+    mocks.hub.onclose.mockReset();
+    mocks.hub.onreconnecting.mockReset();
     mocks.hub.start.mockReset();
     mocks.hub.stop.mockReset();
     mocks.hub.state = 'Connected';
     mocks.handlers.clear();
-    mocks.tokenListeners.clear();
+    mocks.closeHandler = null;
+    mocks.reconnectingHandler = null;
     mocks.builder.withUrl.mockClear();
     mocks.builder.withAutomaticReconnect.mockClear();
     mocks.builder.configureLogging.mockClear();
@@ -89,16 +91,16 @@ describe('RealtimeProvider', () => {
     mocks.hub.off.mockImplementation((eventName: string, handler: Handler) => {
       if (mocks.handlers.get(eventName) === handler) mocks.handlers.delete(eventName);
     });
+    mocks.hub.onclose.mockImplementation((handler: Handler) => {
+      mocks.closeHandler = handler;
+    });
+    mocks.hub.onreconnecting.mockImplementation((handler: Handler) => {
+      mocks.reconnectingHandler = handler;
+    });
     mocks.builder.withUrl.mockReturnValue(mocks.builder);
     mocks.builder.withAutomaticReconnect.mockReturnValue(mocks.builder);
     mocks.builder.configureLogging.mockReturnValue(mocks.builder);
     mocks.builder.build.mockReturnValue(mocks.hub);
-    mocks.subscribeToTokenChanges.mockImplementation((listener: TokenChangeListener) => {
-      mocks.tokenListeners.add(listener);
-      return () => {
-        mocks.tokenListeners.delete(listener);
-      };
-    });
   });
 
   it('keeps the default disconnected state while unauthenticated', () => {
@@ -113,9 +115,9 @@ describe('RealtimeProvider', () => {
     expect(mocks.builder.build).not.toHaveBeenCalled();
   });
 
-  it('starts a SignalR hub for authenticated users and marks it ready on the ready event', async () => {
+  it('starts SignalR with the shared fresh-token factory and handles ready events', async () => {
     mocks.isAuthenticated = true;
-    mocks.getAccessToken.mockReturnValue('access-token');
+    mocks.getFreshAccessToken.mockResolvedValue('access-token');
     mocks.hub.start.mockResolvedValueOnce(undefined);
 
     render(
@@ -125,13 +127,10 @@ describe('RealtimeProvider', () => {
     );
 
     await waitFor(() => expect(screen.getByTestId('connection')).toHaveTextContent('connected'));
-    expect(screen.getByTestId('ready')).toHaveTextContent('false');
     expect(mocks.builder.withUrl).toHaveBeenCalledWith(expect.any(String), {
-      accessTokenFactory: expect.any(Function),
+      accessTokenFactory: mocks.getFreshAccessToken,
     });
     expect(mocks.builder.withAutomaticReconnect).toHaveBeenCalledWith([2000, 5000, 10000, 30000]);
-    expect(mocks.builder.configureLogging).toHaveBeenCalledWith('Warning');
-    expect(mocks.builder.withUrl.mock.calls[0][1].accessTokenFactory()).toBe('access-token');
 
     act(() => {
       mocks.handlers.get(REALTIME_SERVER_EVENTS.ready)?.();
@@ -140,9 +139,46 @@ describe('RealtimeProvider', () => {
     expect(screen.getByTestId('ready')).toHaveTextContent('true');
   });
 
+  it('marks the connection unready while SignalR reconnects', async () => {
+    mocks.isAuthenticated = true;
+    mocks.hub.start.mockResolvedValueOnce(undefined);
+
+    render(
+      <RealtimeProvider>
+        <RealtimeConsumer />
+      </RealtimeProvider>
+    );
+
+    await waitFor(() => expect(screen.getByTestId('connection')).toHaveTextContent('connected'));
+    act(() => mocks.handlers.get(REALTIME_SERVER_EVENTS.ready)?.());
+    expect(screen.getByTestId('ready')).toHaveTextContent('true');
+
+    act(() => mocks.reconnectingHandler?.());
+
+    expect(screen.getByTestId('connection')).toHaveTextContent('connected');
+    expect(screen.getByTestId('ready')).toHaveTextContent('false');
+  });
+
+  it('recreates a terminally closed connection after automatic reconnect is exhausted', async () => {
+    mocks.isAuthenticated = true;
+    mocks.hub.start.mockResolvedValue(undefined);
+
+    render(
+      <RealtimeProvider>
+        <RealtimeConsumer />
+      </RealtimeProvider>
+    );
+
+    await waitFor(() => expect(mocks.hub.start).toHaveBeenCalledTimes(1));
+
+    act(() => mocks.closeHandler?.());
+
+    await waitFor(() => expect(mocks.hub.start).toHaveBeenCalledTimes(2));
+    expect(mocks.builder.build).toHaveBeenCalledTimes(2);
+  });
+
   it('removes handlers and stops an active hub on unmount', async () => {
     mocks.isAuthenticated = true;
-    mocks.getAccessToken.mockReturnValue('access-token');
     mocks.hub.start.mockResolvedValueOnce(undefined);
 
     const { unmount } = render(
@@ -158,33 +194,8 @@ describe('RealtimeProvider', () => {
     expect(mocks.hub.stop).toHaveBeenCalledTimes(1);
   });
 
-  it('restarts the hub when the stored access token changes', async () => {
-    mocks.isAuthenticated = true;
-    mocks.getAccessToken.mockReturnValue('old-access-token');
-    mocks.hub.start.mockResolvedValue(undefined);
-
-    render(
-      <RealtimeProvider>
-        <RealtimeConsumer />
-      </RealtimeProvider>
-    );
-
-    await waitFor(() => expect(mocks.hub.start).toHaveBeenCalledTimes(1));
-    expect(mocks.builder.withUrl.mock.calls[0][1].accessTokenFactory()).toBe('old-access-token');
-
-    act(() => {
-      mocks.getAccessToken.mockReturnValue('new-access-token');
-      mocks.tokenListeners.forEach((listener) => listener('new-access-token'));
-    });
-
-    await waitFor(() => expect(mocks.hub.stop).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(mocks.hub.start).toHaveBeenCalledTimes(2));
-    expect(mocks.builder.withUrl.mock.calls[1][1].accessTokenFactory()).toBe('new-access-token');
-  });
-
   it('does not stop a hub that is already disconnected', async () => {
     mocks.isAuthenticated = true;
-    mocks.getAccessToken.mockReturnValue('access-token');
     mocks.hub.state = 'Disconnected';
     mocks.hub.start.mockResolvedValueOnce(undefined);
 
@@ -204,7 +215,6 @@ describe('RealtimeProvider', () => {
     const error = new Error('boom');
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     mocks.isAuthenticated = true;
-    mocks.getAccessToken.mockReturnValue('access-token');
     mocks.hub.start.mockRejectedValueOnce(error);
 
     render(

--- a/apps/harmonie/src/features/realtime/RealtimeContext.tsx
+++ b/apps/harmonie/src/features/realtime/RealtimeContext.tsx
@@ -5,7 +5,7 @@ import {
   LogLevel,
   type HubConnection,
 } from '@microsoft/signalr';
-import { getAccessToken, subscribeToTokenChanges } from '@/api/authStorage';
+import { getFreshAccessToken } from '@/api/client';
 import { useAuth } from '@/features/auth/AuthContext';
 import { REALTIME_SERVER_EVENTS } from './constants';
 
@@ -17,7 +17,6 @@ interface RealtimeContextValue {
 }
 
 interface RealtimeState {
-  authKey: string | null;
   connection: HubConnection | null;
   isReady: boolean;
 }
@@ -26,47 +25,59 @@ const RealtimeContext = createContext<RealtimeContextValue>({ connection: null, 
 
 export const RealtimeProvider = ({ children }: { children: ReactNode }) => {
   const { isAuthenticated } = useAuth();
-  const [accessToken, setAccessToken] = useState(() => getAccessToken());
-  const authKey = isAuthenticated ? accessToken : null;
-  const [state, setState] = useState<RealtimeState>({
-    authKey: null,
-    connection: null,
-    isReady: false,
-  });
-  const connection = authKey !== null && state.authKey === authKey ? state.connection : null;
-  const isReady = authKey !== null && state.authKey === authKey ? state.isReady : false;
-
-  useEffect(() => subscribeToTokenChanges(setAccessToken), []);
+  const [restartVersion, setRestartVersion] = useState(0);
+  const [state, setState] = useState<RealtimeState>({ connection: null, isReady: false });
+  const connection = isAuthenticated ? state.connection : null;
+  const isReady = isAuthenticated ? state.isReady : false;
 
   useEffect(() => {
-    if (authKey === null) return;
+    if (!isAuthenticated) return;
 
     const hub = new HubConnectionBuilder()
       .withUrl(HUB_URL, {
-        accessTokenFactory: () => getAccessToken() ?? '',
+        accessTokenFactory: getFreshAccessToken,
       })
       .withAutomaticReconnect([2000, 5000, 10000, 30000])
       .configureLogging(LogLevel.Warning)
       .build();
 
     let cancelled = false;
+    let receivedReady = false;
     const handleReady = () => {
+      receivedReady = true;
       if (!cancelled) {
         setState((current) =>
           current.connection === hub ? { ...current, isReady: true } : current
         );
       }
     };
+    const handleReconnecting = () => {
+      if (!cancelled) {
+        setState((current) =>
+          current.connection === hub ? { ...current, isReady: false } : current
+        );
+      }
+    };
+    const handleClose = () => {
+      if (cancelled) return;
+
+      setState((current) =>
+        current.connection === hub ? { connection: null, isReady: false } : current
+      );
+      setRestartVersion((current) => current + 1);
+    };
 
     hub.on(REALTIME_SERVER_EVENTS.ready, handleReady);
+    hub.onreconnecting(handleReconnecting);
+    hub.onclose(handleClose);
 
     hub
       .start()
       .then(() => {
-        if (!cancelled) setState({ authKey, connection: hub, isReady: false });
+        if (!cancelled) setState({ connection: hub, isReady: receivedReady });
       })
       .catch((err) => {
-        console.error('[Realtime] hub.start() failed:', err);
+        if (!cancelled) console.error('[Realtime] hub.start() failed:', err);
       });
 
     return () => {
@@ -76,7 +87,7 @@ export const RealtimeProvider = ({ children }: { children: ReactNode }) => {
         hub.stop();
       }
     };
-  }, [authKey]);
+  }, [isAuthenticated, restartVersion]);
 
   return (
     <RealtimeContext.Provider value={{ connection, isReady }}>{children}</RealtimeContext.Provider>

--- a/apps/harmonie/src/features/realtime/RealtimeContext.tsx
+++ b/apps/harmonie/src/features/realtime/RealtimeContext.tsx
@@ -25,7 +25,6 @@ const RealtimeContext = createContext<RealtimeContextValue>({ connection: null, 
 
 export const RealtimeProvider = ({ children }: { children: ReactNode }) => {
   const { isAuthenticated } = useAuth();
-  const [restartVersion, setRestartVersion] = useState(0);
   const [state, setState] = useState<RealtimeState>({ connection: null, isReady: false });
   const connection = isAuthenticated ? state.connection : null;
   const isReady = isAuthenticated ? state.isReady : false;
@@ -42,39 +41,28 @@ export const RealtimeProvider = ({ children }: { children: ReactNode }) => {
       .build();
 
     let cancelled = false;
-    let receivedReady = false;
     const handleReady = () => {
-      receivedReady = true;
       if (!cancelled) {
         setState((current) =>
           current.connection === hub ? { ...current, isReady: true } : current
         );
       }
     };
-    const handleReconnecting = () => {
+    const handleClose = () => {
       if (!cancelled) {
         setState((current) =>
-          current.connection === hub ? { ...current, isReady: false } : current
+          current.connection === hub ? { connection: null, isReady: false } : current
         );
       }
     };
-    const handleClose = () => {
-      if (cancelled) return;
-
-      setState((current) =>
-        current.connection === hub ? { connection: null, isReady: false } : current
-      );
-      setRestartVersion((current) => current + 1);
-    };
 
     hub.on(REALTIME_SERVER_EVENTS.ready, handleReady);
-    hub.onreconnecting(handleReconnecting);
     hub.onclose(handleClose);
 
     hub
       .start()
       .then(() => {
-        if (!cancelled) setState({ connection: hub, isReady: receivedReady });
+        if (!cancelled) setState({ connection: hub, isReady: false });
       })
       .catch((err) => {
         if (!cancelled) console.error('[Realtime] hub.start() failed:', err);
@@ -87,7 +75,7 @@ export const RealtimeProvider = ({ children }: { children: ReactNode }) => {
         hub.stop();
       }
     };
-  }, [isAuthenticated, restartVersion]);
+  }, [isAuthenticated]);
 
   return (
     <RealtimeContext.Provider value={{ connection, isReady }}>{children}</RealtimeContext.Provider>

--- a/apps/harmonie/src/types/auth.ts
+++ b/apps/harmonie/src/types/auth.ts
@@ -50,4 +50,5 @@ export interface LogoutRequest {
 export interface TokensPayload {
   accessToken: string;
   refreshToken: string;
+  expiresAt: string;
 }


### PR DESCRIPTION
## Summary

- refresh expired or soon-to-expire access tokens before SignalR negotiate/reconnect
- share one in-flight refresh operation between HTTP requests and SignalR
- preserve the existing realtime connection during token rotation
- stop exposing a hub after a terminal disconnect, without adding a competing reconnect loop
- add coverage for JWT expiry, refresh deduplication, token-factory wiring, terminal closure, and authentication failures

## Related issues

Closes #197

Client-side prerequisite for Harmonie-chat/harmonie-server#408.

## Validation

- `pnpm --filter @harmonie/app test` — 561 tests passed
- `pnpm --filter @harmonie/app test:typecheck`
- `pnpm --filter @harmonie/app lint`
- `pnpm --filter @harmonie/app build`
- `pnpm format:check`