### PR TITLE
feat: add Web Push notifications

### DIFF
--- a/apps/harmonie/public/sw.js
+++ b/apps/harmonie/public/sw.js
@@ -57,3 +57,81 @@ self.addEventListener('fetch', (event) => {
     })
   );
 });
+
+const buildNotificationTargetUrl = (payload) => {
+  const data = payload?.data;
+  if (!data || payload.type !== 'message.created') return '/';
+
+  if (data.scope === 'channel' && data.guildId && data.channelId) {
+    return `/guilds/${data.guildId}/channels/${data.channelId}`;
+  }
+
+  if (data.scope === 'conversation' && data.conversationId) {
+    return `/conversations/${data.conversationId}`;
+  }
+
+  return '/';
+};
+
+const buildNotificationTitle = (payload) => {
+  const data = payload?.data ?? {};
+  const author = data.authorDisplayName || 'Harmonie';
+
+  if (data.scope === 'channel') {
+    const guild = data.guildName || 'Harmonie';
+    const channel = data.channelName || '';
+    return channel ? `${author} - ${guild} | ${channel}` : `${author} - ${guild}`;
+  }
+
+  if (data.scope === 'conversation') {
+    return data.conversationName ? `${author} - ${data.conversationName}` : author;
+  }
+
+  return 'Harmonie';
+};
+
+const parsePushPayload = (event) => {
+  if (!event.data) return null;
+
+  try {
+    return event.data.json();
+  } catch {
+    return null;
+  }
+};
+
+self.addEventListener('push', (event) => {
+  const payload = parsePushPayload(event);
+  if (!payload) return;
+
+  const messageId = payload?.data?.messageId;
+  const targetUrl = buildNotificationTargetUrl(payload);
+
+  event.waitUntil(
+    self.registration.showNotification(buildNotificationTitle(payload), {
+      tag: messageId ? `message-${messageId}` : 'harmonie-message',
+      icon: '/harmonie.png',
+      badge: '/pwa-icon-192.png',
+      data: { targetUrl },
+    })
+  );
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const targetUrl = event.notification.data?.targetUrl || '/';
+  const absoluteTargetUrl = new URL(targetUrl, self.location.origin).href;
+
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
+      for (const client of clientList) {
+        const clientUrl = new URL(client.url);
+        if (clientUrl.origin !== self.location.origin) continue;
+
+        return client.focus().then(() => client.navigate(absoluteTargetUrl));
+      }
+
+      return self.clients.openWindow(absoluteTargetUrl);
+    })
+  );
+});

--- a/apps/harmonie/src/api/notifications.test.ts
+++ b/apps/harmonie/src/api/notifications.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const apiFetchMock = vi.fn();
+
+vi.mock('./client', () => ({
+  apiFetch: apiFetchMock,
+}));
+
+describe('notifications api', () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+  });
+
+  it('loads the web push public key', async () => {
+    apiFetchMock.mockResolvedValueOnce(Response.json({ publicKey: 'vapid-key' }));
+    const { getWebPushPublicKey } = await import('./notifications');
+
+    await expect(getWebPushPublicKey()).resolves.toEqual({ publicKey: 'vapid-key' });
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      'https://localhost:5000/api/notifications/web-push-public-key'
+    );
+  });
+
+  it('registers a serialized web push subscription', async () => {
+    apiFetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    const { registerWebPushSubscription } = await import('./notifications');
+
+    await expect(
+      registerWebPushSubscription({
+        endpoint: 'https://push.example/subscription',
+        expirationTime: null,
+        keys: {
+          p256dh: 'p256dh-key',
+          auth: 'auth-key',
+        },
+      })
+    ).resolves.toBeUndefined();
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      'https://localhost:5000/api/notifications/push-subscriptions',
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          endpoint: 'https://push.example/subscription',
+          expirationTime: null,
+          keys: {
+            p256dh: 'p256dh-key',
+            auth: 'auth-key',
+          },
+        }),
+      }
+    );
+  });
+
+  it('throws parsed API errors', async () => {
+    apiFetchMock.mockResolvedValueOnce(
+      Response.json({ code: 'NOTIFICATION_WEB_PUSH_NOT_CONFIGURED' }, { status: 503 })
+    );
+    const { getWebPushPublicKey } = await import('./notifications');
+
+    await expect(getWebPushPublicKey()).rejects.toEqual({
+      code: 'NOTIFICATION_WEB_PUSH_NOT_CONFIGURED',
+    });
+  });
+});

--- a/apps/harmonie/src/api/notifications.ts
+++ b/apps/harmonie/src/api/notifications.ts
@@ -1,0 +1,41 @@
+import { apiFetch } from './client';
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL;
+
+export interface WebPushPublicKeyResponse {
+  publicKey: string;
+}
+
+export interface WebPushSubscriptionRequest {
+  endpoint: string;
+  expirationTime: number | string | null;
+  keys: {
+    p256dh: string;
+    auth: string;
+  };
+}
+
+export const getWebPushPublicKey = (): Promise<WebPushPublicKeyResponse> =>
+  apiFetch(`${API_BASE}/notifications/web-push-public-key`).then(async (res) => {
+    if (!res.ok) throw await res.json();
+    return res.json();
+  });
+
+export const registerWebPushSubscription = (subscription: PushSubscriptionJSON): Promise<void> => {
+  const body: WebPushSubscriptionRequest = {
+    endpoint: subscription.endpoint ?? '',
+    expirationTime: subscription.expirationTime ?? null,
+    keys: {
+      p256dh: subscription.keys?.p256dh ?? '',
+      auth: subscription.keys?.auth ?? '',
+    },
+  };
+
+  return apiFetch(`${API_BASE}/notifications/push-subscriptions`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }).then(async (res) => {
+    if (!res.ok) throw await res.json();
+  });
+};

--- a/apps/harmonie/src/features/auth/AuthContext.tsx
+++ b/apps/harmonie/src/features/auth/AuthContext.tsx
@@ -3,6 +3,7 @@ import { logout as logoutApi, refreshTokens } from '@/api/auth';
 import { clearTokens, getRefreshToken, storeTokens } from '@/api/authStorage';
 import { setLogoutHandler } from '@/api/client';
 import type { ApiError } from '@/types/error';
+import { disableWebPushNotificationsLocally } from '@/shared/notifications/webPush';
 
 interface AuthContextValue {
   isAuthenticated: boolean;
@@ -32,6 +33,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   useEffect(() => {
     setLogoutHandler(() => {
+      void disableWebPushNotificationsLocally().catch(() => {});
       clearTokens();
       setIsAuthenticated(false);
     });
@@ -66,6 +68,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         void error;
       }
     }
+    await disableWebPushNotificationsLocally().catch(() => {});
     clearTokens();
     setIsAuthenticated(false);
   };

--- a/apps/harmonie/src/features/realtime/MessageActivityContext.test.tsx
+++ b/apps/harmonie/src/features/realtime/MessageActivityContext.test.tsx
@@ -17,7 +17,6 @@ const mocks = vi.hoisted(() => ({
   guilds: [] as Array<{ guildId: string; hasUnread?: boolean }>,
   handlers: new Map<string, Handler>(),
   params: {} as { guildId?: string },
-  requestPermission: vi.fn(),
   showNotification: vi.fn(),
   textChannelMatch: null as null | { params: { channelId?: string } },
   conversationMatch: null as null | { params: { conversationId?: string } },
@@ -58,7 +57,6 @@ vi.mock('@/features/user/UserContext', () => ({
 }));
 
 vi.mock('@/shared/notifications/browserNotification', () => ({
-  requestBrowserNotificationPermission: mocks.requestPermission,
   showBrowserNotification: mocks.showNotification,
 }));
 
@@ -136,7 +134,6 @@ describe('MessageActivityProvider', () => {
     mocks.guilds = [];
     mocks.handlers.clear();
     mocks.params = {};
-    mocks.requestPermission.mockReset();
     mocks.showNotification.mockReset();
     mocks.textChannelMatch = null;
     mocks.conversationMatch = null;
@@ -185,15 +182,6 @@ describe('MessageActivityProvider', () => {
     expect(screen.getByTestId('guild-1')).toHaveTextContent('false');
     expect(screen.getByTestId('conversation-1')).toHaveTextContent('false');
     expect(screen.getByTestId('any-conversation')).toHaveTextContent('false');
-  });
-
-  it('requests browser notification permission after user interaction', () => {
-    renderProvider();
-
-    fireEvent.pointerDown(window);
-    fireEvent.keyDown(window);
-
-    expect(mocks.requestPermission).toHaveBeenCalledTimes(2);
   });
 
   it('tracks realtime guild channel activity and clears current-route counts on focus', async () => {

--- a/apps/harmonie/src/features/realtime/MessageActivityContext.test.tsx
+++ b/apps/harmonie/src/features/realtime/MessageActivityContext.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MessageActivityProvider, useMessageActivity } from './MessageActivityContext';
+import type { PushNotificationStatus } from '@/shared/notifications/webPush';
 import { REALTIME_SERVER_EVENTS } from './constants';
 
 type Handler = (event: Record<string, unknown>) => void;
@@ -17,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   guilds: [] as Array<{ guildId: string; hasUnread?: boolean }>,
   handlers: new Map<string, Handler>(),
   params: {} as { guildId?: string },
+  pushNotificationStatus: 'prompt' as PushNotificationStatus,
   showNotification: vi.fn(),
   textChannelMatch: null as null | { params: { channelId?: string } },
   conversationMatch: null as null | { params: { conversationId?: string } },
@@ -58,6 +60,10 @@ vi.mock('@/features/user/UserContext', () => ({
 
 vi.mock('@/shared/notifications/browserNotification', () => ({
   showBrowserNotification: mocks.showNotification,
+}));
+
+vi.mock('@/shared/notifications/PushNotificationContext', () => ({
+  usePushNotifications: () => ({ status: mocks.pushNotificationStatus }),
 }));
 
 const ActivityConsumer = () => {
@@ -134,6 +140,7 @@ describe('MessageActivityProvider', () => {
     mocks.guilds = [];
     mocks.handlers.clear();
     mocks.params = {};
+    mocks.pushNotificationStatus = 'prompt';
     mocks.showNotification.mockReset();
     mocks.textChannelMatch = null;
     mocks.conversationMatch = null;
@@ -297,6 +304,24 @@ describe('MessageActivityProvider', () => {
 
     expect(screen.getByTestId('total')).toHaveTextContent('2');
     hasFocus.mockRestore();
+  });
+
+  it('does not duplicate browser notifications when web push is enabled', async () => {
+    createConnection();
+    mocks.pushNotificationStatus = 'enabled';
+
+    renderProvider();
+
+    await waitFor(() =>
+      expect(mocks.handlers.has(REALTIME_SERVER_EVENTS.messageCreated)).toBe(true)
+    );
+
+    act(() => {
+      mocks.handlers.get(REALTIME_SERVER_EVENTS.messageCreated)?.(channelMessage());
+    });
+
+    expect(screen.getByTestId('channel-1')).toHaveTextContent('true');
+    expect(mocks.showNotification).not.toHaveBeenCalled();
   });
 
   it('unsubscribes realtime handlers on unmount', async () => {

--- a/apps/harmonie/src/features/realtime/MessageActivityContext.tsx
+++ b/apps/harmonie/src/features/realtime/MessageActivityContext.tsx
@@ -7,10 +7,7 @@ import { useRealtime } from '@/features/realtime/RealtimeContext';
 import { useUser } from '@/features/user/UserContext';
 import type { MessageCreatedEvent } from '@/types/channel';
 import type { ConversationMessageCreatedEvent } from '@/types/conversation';
-import {
-  requestBrowserNotificationPermission,
-  showBrowserNotification,
-} from '@/shared/notifications/browserNotification';
+import { showBrowserNotification } from '@/shared/notifications/browserNotification';
 import { REALTIME_SERVER_EVENTS } from './constants';
 
 interface MessageActivityContextValue {
@@ -227,20 +224,6 @@ export const MessageActivityProvider = ({ children }: { children: ReactNode }) =
       channelIds: channels.map((channel) => channel.channelId),
     });
   }, [channels, currentRouteGuildId]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-
-    const handleUserInteraction = () => requestBrowserNotificationPermission();
-
-    window.addEventListener('pointerdown', handleUserInteraction, { passive: true });
-    window.addEventListener('keydown', handleUserInteraction);
-
-    return () => {
-      window.removeEventListener('pointerdown', handleUserInteraction);
-      window.removeEventListener('keydown', handleUserInteraction);
-    };
-  }, []);
 
   // Clear current-route unread when the tab regains focus
   useEffect(() => {

--- a/apps/harmonie/src/features/realtime/MessageActivityContext.tsx
+++ b/apps/harmonie/src/features/realtime/MessageActivityContext.tsx
@@ -8,6 +8,7 @@ import { useUser } from '@/features/user/UserContext';
 import type { MessageCreatedEvent } from '@/types/channel';
 import type { ConversationMessageCreatedEvent } from '@/types/conversation';
 import { showBrowserNotification } from '@/shared/notifications/browserNotification';
+import { usePushNotifications } from '@/shared/notifications/PushNotificationContext';
 import { REALTIME_SERVER_EVENTS } from './constants';
 
 interface MessageActivityContextValue {
@@ -171,6 +172,7 @@ const clearedActivityReducer = (
 
 export const MessageActivityProvider = ({ children }: { children: ReactNode }) => {
   const { connection } = useRealtime();
+  const { status: pushNotificationStatus } = usePushNotifications();
   const { user } = useUser();
   const { guilds } = useGuilds();
   const { channels } = useChannels();
@@ -249,7 +251,9 @@ export const MessageActivityProvider = ({ children }: { children: ReactNode }) =
         event.channelId
       )} | ${senderName}`;
 
-      const notify = () =>
+      const notify = () => {
+        if (pushNotificationStatus === 'enabled') return;
+
         showBrowserNotification({
           messageId: event.messageId,
           content: event.content,
@@ -257,6 +261,7 @@ export const MessageActivityProvider = ({ children }: { children: ReactNode }) =
           targetUrl,
           title,
         });
+      };
 
       if (event.guildId !== currentRouteGuildId) {
         dispatchClearedActivity({
@@ -285,7 +290,7 @@ export const MessageActivityProvider = ({ children }: { children: ReactNode }) =
 
     connection.on(REALTIME_SERVER_EVENTS.messageCreated, handleMessageCreated);
     return () => connection.off(REALTIME_SERVER_EVENTS.messageCreated, handleMessageCreated);
-  }, [connection, currentRouteGuildId, activeTextChannelId, user?.userId]);
+  }, [connection, currentRouteGuildId, activeTextChannelId, user?.userId, pushNotificationStatus]);
 
   // Conversation messages
   useEffect(() => {
@@ -304,7 +309,9 @@ export const MessageActivityProvider = ({ children }: { children: ReactNode }) =
           ? senderName
           : `${conversationName} | ${senderName}`;
 
-      const notify = () =>
+      const notify = () => {
+        if (pushNotificationStatus === 'enabled') return;
+
         showBrowserNotification({
           messageId: event.messageId,
           content: event.content,
@@ -312,6 +319,7 @@ export const MessageActivityProvider = ({ children }: { children: ReactNode }) =
           targetUrl,
           title,
         });
+      };
 
       if (event.conversationId !== activeConversationId) {
         dispatchClearedActivity({
@@ -336,7 +344,7 @@ export const MessageActivityProvider = ({ children }: { children: ReactNode }) =
         REALTIME_SERVER_EVENTS.conversationMessageCreated,
         handleConversationMessageCreated
       );
-  }, [connection, activeConversationId, user?.userId]);
+  }, [connection, activeConversationId, user?.userId, pushNotificationStatus]);
 
   useEffect(() => {
     if (!activeTextChannelId) return;

--- a/apps/harmonie/src/features/user/settings/NotificationsSection.test.tsx
+++ b/apps/harmonie/src/features/user/settings/NotificationsSection.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NotificationsSection } from './NotificationsSection';
+import type { PushNotificationStatus } from '@/shared/notifications/webPush';
+
+const mocks = vi.hoisted(() => ({
+  disable: vi.fn(),
+  enable: vi.fn(),
+  status: 'prompt' as PushNotificationStatus,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/shared/notifications/PushNotificationContext', () => ({
+  usePushNotifications: () => ({
+    disable: mocks.disable,
+    enable: mocks.enable,
+    status: mocks.status,
+  }),
+}));
+
+describe('NotificationsSection', () => {
+  beforeEach(() => {
+    mocks.disable.mockReset();
+    mocks.enable.mockReset();
+    mocks.enable.mockResolvedValue(undefined);
+    mocks.disable.mockResolvedValue(undefined);
+    mocks.status = 'prompt';
+  });
+
+  it('enables push notifications from the prompt state', () => {
+    render(<NotificationsSection />);
+
+    expect(screen.getByText('notifications.push.disabledDescription')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'notifications.push.enable' }));
+
+    expect(mocks.enable).toHaveBeenCalledOnce();
+    expect(mocks.disable).not.toHaveBeenCalled();
+  });
+
+  it('disables push notifications from the enabled state', () => {
+    mocks.status = 'enabled';
+
+    render(<NotificationsSection />);
+
+    expect(screen.getByText('notifications.push.enabledDescription')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'notifications.push.disable' }));
+
+    expect(mocks.disable).toHaveBeenCalledOnce();
+    expect(mocks.enable).not.toHaveBeenCalled();
+  });
+
+  it('disables the action when permission is denied', () => {
+    mocks.status = 'denied';
+
+    render(<NotificationsSection />);
+
+    expect(screen.getByText('notifications.push.denied')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'notifications.push.enable' })).toBeDisabled();
+  });
+});

--- a/apps/harmonie/src/features/user/settings/NotificationsSection.tsx
+++ b/apps/harmonie/src/features/user/settings/NotificationsSection.tsx
@@ -1,0 +1,60 @@
+import { Bell, BellOff } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@harmonie/ui';
+import { usePushNotifications } from '@/shared/notifications/PushNotificationContext';
+
+export const NotificationsSection = () => {
+  const { t } = useTranslation();
+  const { disable, enable, status } = usePushNotifications();
+  const isLoading = status === 'syncing';
+  const isEnabled = status === 'enabled';
+  const canEnable = status === 'disabled' || status === 'prompt' || status === 'error';
+  const canDisable = status === 'enabled';
+  const actionLabel = isEnabled ? t('notifications.push.disable') : t('notifications.push.enable');
+  const descriptionKey =
+    status === 'unsupported'
+      ? 'unsupported'
+      : status === 'denied'
+        ? 'denied'
+        : status === 'enabled'
+          ? 'enabledDescription'
+          : status === 'error'
+            ? 'error'
+            : 'disabledDescription';
+
+  const handleToggle = () => {
+    if (isEnabled) {
+      void disable();
+      return;
+    }
+
+    void enable().catch(() => {});
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-start gap-3 rounded-lg border border-secondary bg-surface-2 p-4">
+        <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-surface-3 text-text-2">
+          {isEnabled ? <Bell size={18} /> : <BellOff size={18} />}
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-text-1">{t('notifications.push.title')}</p>
+          <p className="mt-1 text-sm leading-relaxed text-text-2">
+            {t(`notifications.push.${descriptionKey}`)}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex justify-end">
+        <Button
+          variant={isEnabled ? 'secondary' : 'primary'}
+          onClick={handleToggle}
+          disabled={!(canEnable || canDisable)}
+          isLoading={isLoading}
+        >
+          {actionLabel}
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/apps/harmonie/src/features/user/settings/SettingsPanel.test.tsx
+++ b/apps/harmonie/src/features/user/settings/SettingsPanel.test.tsx
@@ -79,6 +79,10 @@ vi.mock('./ThemeSection', () => ({
   ThemeSection: () => <div>theme section</div>,
 }));
 
+vi.mock('./NotificationsSection', () => ({
+  NotificationsSection: () => <div>notifications section</div>,
+}));
+
 describe('SettingsPanel', () => {
   it('switches sections, closes, and logs out', () => {
     const onClose = vi.fn();
@@ -103,6 +107,9 @@ describe('SettingsPanel', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'settings.nav.theme' }));
     expect(screen.getByText('theme section')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'settings.nav.notifications' }));
+    expect(screen.getByText('notifications section')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'user.logout' }));
     fireEvent.click(screen.getByRole('button', { name: 'close settings' }));

--- a/apps/harmonie/src/features/user/settings/SettingsPanel.tsx
+++ b/apps/harmonie/src/features/user/settings/SettingsPanel.tsx
@@ -1,16 +1,17 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { FileText, Globe, LogOut, Palette, UserRound } from 'lucide-react';
+import { Bell, FileText, Globe, LogOut, Palette, UserRound } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { ModalPanel, NavList, NavListItem, Separator } from '@harmonie/ui';
 import { useAuth } from '@/features/auth/AuthContext';
 import { useUser } from '@/features/user/UserContext';
 import { AvatarSection } from './AvatarSection';
 import { LanguageSection } from './LanguageSection';
+import { NotificationsSection } from './NotificationsSection';
 import { ProfileSection } from './ProfileSection';
 import { ThemeSection } from './ThemeSection';
 
-type Section = 'profile' | 'language' | 'avatar' | 'theme';
+type Section = 'profile' | 'language' | 'avatar' | 'theme' | 'notifications';
 
 interface SettingsPanelProps {
   onClose: () => void;
@@ -21,6 +22,7 @@ const NAV_ITEMS: { id: Section; icon: LucideIcon }[] = [
   { id: 'language', icon: Globe },
   { id: 'avatar', icon: UserRound },
   { id: 'theme', icon: Palette },
+  { id: 'notifications', icon: Bell },
 ];
 
 export const SettingsPanel = ({ onClose }: SettingsPanelProps) => {
@@ -66,6 +68,7 @@ export const SettingsPanel = ({ onClose }: SettingsPanelProps) => {
       {section === 'language' && <LanguageSection updateUser={updateUser} />}
       {section === 'avatar' && <AvatarSection user={user} updateUser={updateUser} />}
       {section === 'theme' && <ThemeSection />}
+      {section === 'notifications' && <NotificationsSection />}
     </ModalPanel>
   );
 };

--- a/apps/harmonie/src/i18n/locales/en.ts
+++ b/apps/harmonie/src/i18n/locales/en.ts
@@ -33,6 +33,19 @@ export const en = {
       attachmentOnly: 'New message with attachment.',
       fallbackBody: 'Harmonie - New message.',
     },
+    push: {
+      title: 'Push notifications',
+      promptTitle: 'Enable notifications?',
+      promptDescription: 'Receive new messages even when Harmonie is not open.',
+      enabledDescription: 'Push notifications are enabled on this device.',
+      disabledDescription: 'Enable notifications to receive new messages.',
+      unsupported: 'Push notifications are not available in this browser.',
+      denied: 'Notifications are blocked. Allow them in your browser settings to enable them.',
+      error: 'Unable to set up notifications. Please try again.',
+      enable: 'Enable',
+      disable: 'Disable',
+      dismiss: 'Hide',
+    },
   },
   guild: {
     createTitle: 'Create a guild',
@@ -322,6 +335,7 @@ export const en = {
       language: 'Language',
       avatar: 'Avatar',
       theme: 'Theme',
+      notifications: 'Notifications',
     },
     profile: {
       title: 'Profile',
@@ -369,6 +383,9 @@ export const en = {
       'crimson-obsidian': 'Crimson Obsidian',
       'amethyst-obsidian': 'Amethyst Obsidian',
       'rose-obsidian': 'Blush Obsidian',
+    },
+    notifications: {
+      title: 'Notifications',
     },
   },
   voice: {

--- a/apps/harmonie/src/i18n/locales/fr.ts
+++ b/apps/harmonie/src/i18n/locales/fr.ts
@@ -34,6 +34,20 @@ export const fr = {
       attachmentOnly: 'Nouveau message avec piece jointe.',
       fallbackBody: 'Harmonie - Nouveau message.',
     },
+    push: {
+      title: 'Notifications push',
+      promptTitle: 'Activer les notifications ?',
+      promptDescription: "Reçois les nouveaux messages même quand Harmonie n'est pas ouvert.",
+      enabledDescription: 'Les notifications push sont activées sur cet appareil.',
+      disabledDescription: 'Active les notifications pour recevoir les nouveaux messages.',
+      unsupported: 'Les notifications push ne sont pas disponibles sur ce navigateur.',
+      denied:
+        'Les notifications sont bloquées. Autorise-les dans les réglages du navigateur pour les activer.',
+      error: 'Impossible de configurer les notifications. Réessaie.',
+      enable: 'Activer',
+      disable: 'Désactiver',
+      dismiss: 'Masquer',
+    },
   },
   guild: {
     createTitle: 'Créer une guilde',
@@ -325,6 +339,7 @@ export const fr = {
       language: 'Langue',
       avatar: 'Avatar',
       theme: 'Thème',
+      notifications: 'Notifications',
     },
     profile: {
       title: 'Profil',
@@ -372,6 +387,9 @@ export const fr = {
       'crimson-obsidian': 'Cramoisi Obsidien',
       'amethyst-obsidian': 'Améthyste Obsidienne',
       'rose-obsidian': 'Rose Obsidien',
+    },
+    notifications: {
+      title: 'Notifications',
     },
   },
   voice: {

--- a/apps/harmonie/src/main.tsx
+++ b/apps/harmonie/src/main.tsx
@@ -14,6 +14,7 @@ import { PwaInstallPrompt } from './shared/pwa/PwaInstallPrompt';
 import { registerServiceWorker } from './shared/pwa/registerServiceWorker';
 import { syncKeyboardInset } from './shared/viewport/keyboardInset';
 import { preventAppZoom } from './shared/viewport/preventAppZoom';
+import { PushNotificationProvider } from './shared/notifications/PushNotificationContext';
 
 document.addEventListener('contextmenu', (e) => e.preventDefault());
 registerServiceWorker();
@@ -24,16 +25,18 @@ createRoot(document.getElementById('root')!).render(
   <ThemeProvider>
     <AuthProvider>
       <UserProvider>
-        <AudioInputProvider>
-          <AudioOutputProvider>
-            <VideoInputProvider>
-              <RealtimeProvider>
-                <RouterProvider router={router} />
-                <PwaInstallPrompt />
-              </RealtimeProvider>
-            </VideoInputProvider>
-          </AudioOutputProvider>
-        </AudioInputProvider>
+        <PushNotificationProvider>
+          <AudioInputProvider>
+            <AudioOutputProvider>
+              <VideoInputProvider>
+                <RealtimeProvider>
+                  <RouterProvider router={router} />
+                  <PwaInstallPrompt />
+                </RealtimeProvider>
+              </VideoInputProvider>
+            </AudioOutputProvider>
+          </AudioInputProvider>
+        </PushNotificationProvider>
       </UserProvider>
     </AuthProvider>
   </ThemeProvider>

--- a/apps/harmonie/src/shared/message/MessageThread.test.tsx
+++ b/apps/harmonie/src/shared/message/MessageThread.test.tsx
@@ -665,6 +665,7 @@ describe('MessageThread', () => {
       scrollTop: 20,
     });
 
+    fireEvent.wheel(scrollElement);
     fireEvent.scroll(scrollElement);
 
     await waitFor(() => expect(props.loadMore).toHaveBeenCalledTimes(1));
@@ -740,6 +741,7 @@ describe('MessageThread', () => {
       scrollTop: 120,
     });
 
+    fireEvent.wheel(scrollElement);
     fireEvent.scroll(scrollElement);
 
     expect(props.loadMore).not.toHaveBeenCalled();

--- a/apps/harmonie/src/shared/message/MessageThread.test.tsx
+++ b/apps/harmonie/src/shared/message/MessageThread.test.tsx
@@ -655,7 +655,7 @@ describe('MessageThread', () => {
     expect(screen.queryByLabelText('pinned modal')).not.toBeInTheDocument();
   });
 
-  it('opens context menus, reaction picker and loads more while scrolling', async () => {
+  it('loads more while scrolling near the top', async () => {
     const user = userEvent.setup();
     const { container, props } = renderThread();
     const scrollElement = container.querySelector('.overflow-y-auto')!;
@@ -680,6 +680,11 @@ describe('MessageThread', () => {
     ).not.toBeInTheDocument();
     fireEvent.transitionEnd(screen.getByText('channel.messages.newMessages').parentElement!);
     expect(props.dismissNewMessagesSeparator).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens message context menus and runs their actions', async () => {
+    const user = userEvent.setup();
+    const { props } = renderThread();
 
     await user.click(screen.getByRole('button', { name: 'menu message-1' }));
 
@@ -700,8 +705,24 @@ describe('MessageThread', () => {
 
     await user.click(screen.getByRole('button', { name: 'menu message-1' }));
     await user.click(screen.getByRole('button', { name: 'menu quick react' }));
-
     expect(props.toggleReaction).toHaveBeenCalledWith('message-1', '😀');
+
+    await user.click(screen.getByRole('button', { name: 'menu at message-1' }));
+    await user.click(screen.getByRole('button', { name: 'menu edit' }));
+    expect(props.startEditing).toHaveBeenCalledWith('message-1');
+
+    await user.click(screen.getByRole('button', { name: 'menu message-1' }));
+    await user.click(screen.getByRole('button', { name: 'menu delete' }));
+    await user.click(screen.getByRole('button', { name: 'close modal' }));
+
+    expect(
+      screen.queryByRole('region', { name: 'channel.messages.delete' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('opens the reaction picker and selects a reaction', async () => {
+    const user = userEvent.setup();
+    const { props } = renderThread();
 
     await user.click(screen.getByRole('button', { name: 'menu at message-2' }));
     await user.click(screen.getByRole('button', { name: 'menu picker' }));
@@ -713,23 +734,9 @@ describe('MessageThread', () => {
 
     await user.click(screen.getByRole('button', { name: 'menu at message-2' }));
     await user.click(screen.getByRole('button', { name: 'menu picker' }));
-
     await user.click(screen.getByRole('button', { name: 'picker select' }));
 
     expect(props.toggleReaction).toHaveBeenCalledWith('message-2', '🔥');
-
-    await user.click(screen.getByRole('button', { name: 'menu at message-1' }));
-    await user.click(screen.getByRole('button', { name: 'menu edit' }));
-
-    expect(props.startEditing).toHaveBeenCalledWith('message-1');
-
-    await user.click(screen.getByRole('button', { name: 'menu message-1' }));
-    await user.click(screen.getByRole('button', { name: 'menu delete' }));
-    await user.click(screen.getByRole('button', { name: 'close modal' }));
-
-    expect(
-      screen.queryByRole('region', { name: 'channel.messages.delete' })
-    ).not.toBeInTheDocument();
   });
 
   it('does not load more when already away from the top', async () => {

--- a/apps/harmonie/src/shared/message/MessageThread.tsx
+++ b/apps/harmonie/src/shared/message/MessageThread.tsx
@@ -278,6 +278,17 @@ const useMessageThreadContent = <TAuthor extends MessageAuthor = MessageAuthor>(
       clearTimeout(userScrollIntentTimeoutRef.current);
       userScrollIntentTimeoutRef.current = null;
     }
+
+    return () => {
+      if (pinnedHighlightTimeoutRef.current) {
+        clearTimeout(pinnedHighlightTimeoutRef.current);
+        pinnedHighlightTimeoutRef.current = null;
+      }
+      if (userScrollIntentTimeoutRef.current) {
+        clearTimeout(userScrollIntentTimeoutRef.current);
+        userScrollIntentTimeoutRef.current = null;
+      }
+    };
   }, [
     previousMessageCountRef,
     scrollAnchorRef,

--- a/apps/harmonie/src/shared/message/MessageThread.tsx
+++ b/apps/harmonie/src/shared/message/MessageThread.tsx
@@ -208,6 +208,8 @@ const useMessageThreadContent = <TAuthor extends MessageAuthor = MessageAuthor>(
     showScrollToBottom,
   } = uiState;
   const pinnedHighlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const userScrollIntentRef = useRef(false);
+  const userScrollIntentTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const {
     scrollRef,
@@ -218,22 +220,46 @@ const useMessageThreadContent = <TAuthor extends MessageAuthor = MessageAuthor>(
     shouldStickToBottomRef,
   } = refs;
 
+  const clearUserScrollIntent = () => {
+    userScrollIntentRef.current = false;
+    if (userScrollIntentTimeoutRef.current) {
+      clearTimeout(userScrollIntentTimeoutRef.current);
+      userScrollIntentTimeoutRef.current = null;
+    }
+  };
+
+  const markUserScrollIntent = () => {
+    userScrollIntentRef.current = true;
+    if (userScrollIntentTimeoutRef.current) {
+      clearTimeout(userScrollIntentTimeoutRef.current);
+    }
+    userScrollIntentTimeoutRef.current = setTimeout(() => {
+      userScrollIntentRef.current = false;
+      userScrollIntentTimeoutRef.current = null;
+    }, 350);
+  };
+
   const scrollToBottom = (behavior: ScrollBehavior = 'auto') => {
     const scrollElement = scrollRef.current;
     if (!scrollElement) return;
 
+    clearUserScrollIntent();
+    shouldStickToBottomRef.current = true;
     dispatchUi({ type: 'patch', patch: { showScrollToBottom: false } });
 
     if (behavior === 'smooth') {
+      suppressNextScrollEffectsRef.current = true;
       scrollElement.scrollTo({ top: scrollElement.scrollHeight, behavior });
       return;
     }
 
+    suppressNextScrollEffectsRef.current = true;
     scrollElement.scrollTop = scrollElement.scrollHeight;
 
     requestAnimationFrame(() => {
       const nextScrollElement = scrollRef.current;
       if (!nextScrollElement) return;
+      suppressNextScrollEffectsRef.current = true;
       nextScrollElement.scrollTop = nextScrollElement.scrollHeight;
     });
   };
@@ -246,6 +272,11 @@ const useMessageThreadContent = <TAuthor extends MessageAuthor = MessageAuthor>(
     if (pinnedHighlightTimeoutRef.current) {
       clearTimeout(pinnedHighlightTimeoutRef.current);
       pinnedHighlightTimeoutRef.current = null;
+    }
+    userScrollIntentRef.current = false;
+    if (userScrollIntentTimeoutRef.current) {
+      clearTimeout(userScrollIntentTimeoutRef.current);
+      userScrollIntentTimeoutRef.current = null;
     }
   }, [
     previousMessageCountRef,
@@ -307,6 +338,7 @@ const useMessageThreadContent = <TAuthor extends MessageAuthor = MessageAuthor>(
         requestAnimationFrame(() => {
           const nextScrollElement = scrollRef.current;
           if (!nextScrollElement) return;
+          suppressNextScrollEffectsRef.current = true;
           nextScrollElement.scrollTop = nextScrollElement.scrollHeight;
         });
       }
@@ -315,7 +347,13 @@ const useMessageThreadContent = <TAuthor extends MessageAuthor = MessageAuthor>(
     observer.observe(contentEl);
     observer.observe(scrollEl);
     return () => observer.disconnect();
-  }, [messages.length, messagesContentRef, scrollRef, shouldStickToBottomRef]);
+  }, [
+    messages.length,
+    messagesContentRef,
+    scrollRef,
+    shouldStickToBottomRef,
+    suppressNextScrollEffectsRef,
+  ]);
 
   useEffect(() => {
     if (!editingMessageId) return;
@@ -349,10 +387,21 @@ const useMessageThreadContent = <TAuthor extends MessageAuthor = MessageAuthor>(
     const element = scrollRef.current;
     if (!element) return;
 
+    if (suppressNextScrollEffectsRef.current) {
+      suppressNextScrollEffectsRef.current = false;
+      if (!userScrollIntentRef.current) return;
+    }
+
     if (lastReadMessageId !== null && !separatorDismissed) {
       dispatchUi({ type: 'patch', patch: { separatorDismissed: true } });
     }
     const distanceFromBottom = element.scrollHeight - element.scrollTop - element.clientHeight;
+
+    if (!userScrollIntentRef.current && shouldStickToBottomRef.current && distanceFromBottom > 1) {
+      scrollToBottom();
+      return;
+    }
+
     shouldStickToBottomRef.current = distanceFromBottom < 50;
     dispatchUi({ type: 'patch', patch: { showScrollToBottom: distanceFromBottom > 160 } });
     if (element.scrollTop >= 100) return;
@@ -570,7 +619,9 @@ const useMessageThreadContent = <TAuthor extends MessageAuthor = MessageAuthor>(
           <div
             ref={scrollRef}
             className="h-full overflow-y-auto px-2 sm:px-4 py-4 gap-0"
+            onTouchMove={markUserScrollIntent}
             onScroll={handleMessagesScroll}
+            onWheel={markUserScrollIntent}
           >
             {loading ? (
               <div className="flex h-full items-center justify-center text-text-3 text-sm">

--- a/apps/harmonie/src/shared/message/hooks/useMessages.test.ts
+++ b/apps/harmonie/src/shared/message/hooks/useMessages.test.ts
@@ -121,6 +121,31 @@ describe('useMessages', () => {
     expect(result.current.lastReadMessageId).toBeNull();
   });
 
+  it('normalizes messages with missing optional collections from API responses', async () => {
+    const api = createApi();
+    vi.mocked(api.fetchMessages).mockResolvedValueOnce(
+      messageList({
+        items: [
+          message({
+            attachments: undefined as never,
+            mentionedUserIds: undefined,
+            reactions: undefined as never,
+          }),
+        ],
+      })
+    );
+
+    const { result } = renderUseMessages({ api });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.messages[0]).toMatchObject({
+      attachments: [],
+      mentionedUserIds: [],
+      reactions: [],
+    });
+  });
+
   it('loads more messages and deduplicates existing ids', async () => {
     const api = createApi();
     vi.mocked(api.fetchMessages)
@@ -304,6 +329,29 @@ describe('useMessages', () => {
       'message-2',
     ]);
     expect(api.ackMessage).toHaveBeenCalledWith('channel-1', 'message-2');
+  });
+
+  it('normalizes sent messages from partial API responses', async () => {
+    const api = createApi();
+    vi.mocked(api.fetchMessages).mockResolvedValueOnce(messageList({ items: [] }));
+    const { result } = renderUseMessages({ api });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      result.current.addMessage(
+        message({
+          messageId: 'message-2',
+          attachments: undefined as never,
+          reactions: undefined as never,
+        })
+      );
+    });
+
+    expect(result.current.messages[0]).toMatchObject({
+      messageId: 'message-2',
+      attachments: [],
+      reactions: [],
+    });
   });
 
   it('performs edit, delete, attachment, pin, and reaction actions optimistically', async () => {

--- a/apps/harmonie/src/shared/message/hooks/useMessages.ts
+++ b/apps/harmonie/src/shared/message/hooks/useMessages.ts
@@ -32,6 +32,16 @@ interface WsMessageDeletedEvent {
 
 const EMPTY_MESSAGES: Message[] = [];
 
+const normalizeMessage = (message: Message): Message => ({
+  ...message,
+  mentionedUserIds: message.mentionedUserIds ?? [],
+  attachments: Array.isArray(message.attachments) ? message.attachments : [],
+  reactions: Array.isArray(message.reactions) ? message.reactions : [],
+  linkPreviews: message.linkPreviews ?? null,
+  isPinned: message.isPinned ?? false,
+  replyTo: message.replyTo ?? null,
+});
+
 interface WsReactionEvent {
   messageId: string;
   emoji: string;
@@ -162,7 +172,7 @@ export const useMessages = ({
   const dismissNewMessagesSeparator = () => setLastReadMessageId(null);
 
   const applyFetchedMessages = (requestedEntityId: string, data: MessageList) => {
-    const sorted = sortMessagesAsc(data.items);
+    const sorted = sortMessagesAsc(data.items.map(normalizeMessage));
     setLoadedEntityId(requestedEntityId);
     setMessages(sorted);
     setNextCursor(data.nextCursor);
@@ -187,13 +197,14 @@ export const useMessages = ({
   const addMessage = useCallback(
     (message: Message) => {
       if (!entityId) return;
+      const normalizedMessage = normalizeMessage(message);
       setLoadedEntityId(entityId);
       setError(false);
       setMessages((prev) => {
-        if (prev.some((item) => item.messageId === message.messageId)) return prev;
-        return sortMessagesAsc([...prev, message]);
+        if (prev.some((item) => item.messageId === normalizedMessage.messageId)) return prev;
+        return sortMessagesAsc([...prev, normalizedMessage]);
       });
-      markAsReadRef.current(message.messageId).catch(() => {});
+      markAsReadRef.current(normalizedMessage.messageId).catch(() => {});
     },
     [entityId]
   );
@@ -452,14 +463,15 @@ export const useMessages = ({
     let items: Message[] = [];
     try {
       const data = await apiRef.current.fetchMessages(entityId, cursor);
+      const fetchedItems = data.items.map(normalizeMessage);
       setMessages((prev) => {
         const existingIds = new Set(prev.map((m) => m.messageId));
-        const newItems = sortMessagesAsc(data.items).filter((m) => !existingIds.has(m.messageId));
+        const newItems = sortMessagesAsc(fetchedItems).filter((m) => !existingIds.has(m.messageId));
         return [...newItems, ...prev];
       });
       nextCursorRef.current = data.nextCursor;
       setNextCursor(data.nextCursor);
-      items = data.items;
+      items = fetchedItems;
     } catch {
       items = [];
     }
@@ -502,7 +514,9 @@ export const useMessages = ({
       mentionedUserIds
     );
     setMessages((prev) =>
-      prev.map((m) => (m.messageId === updated.messageId ? { ...m, ...updated } : m))
+      prev.map((m) =>
+        m.messageId === updated.messageId ? normalizeMessage({ ...m, ...updated }) : m
+      )
     );
     setEditingMessageId(null);
   };

--- a/apps/harmonie/src/shared/message/reactions/MessageReactions.test.tsx
+++ b/apps/harmonie/src/shared/message/reactions/MessageReactions.test.tsx
@@ -151,6 +151,12 @@ describe('MessageReactions', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
+  it('renders nothing when reactions are missing from a partial message payload', () => {
+    const { container } = render(<MessageReactions messageId="message-1" onToggle={vi.fn()} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
   it('toggles reactions, shows tooltip, opens channel users, loads more, and closes', async () => {
     const onToggle = vi.fn();
 

--- a/apps/harmonie/src/shared/message/reactions/MessageReactions.tsx
+++ b/apps/harmonie/src/shared/message/reactions/MessageReactions.tsx
@@ -14,7 +14,7 @@ import { MessageReactionUsersModal } from './MessageReactionUsersModal';
 
 interface MessageReactionsProps {
   messageId: string;
-  reactions: MessageReaction[];
+  reactions?: MessageReaction[];
   onToggle: (emoji: string) => void;
   reactionSource?: {
     type: 'channel' | 'conversation';
@@ -62,9 +62,10 @@ export const MessageReactions = ({
     (reactionUsersState.emoji !== selectedEmoji || loadingMoreReactionUsers);
   const reactionUsersError =
     reactionUsersState.emoji === selectedEmoji ? reactionUsersState.error : false;
+  const visibleReactions = reactions ?? [];
 
   const selectedReaction = selectedEmoji
-    ? reactions.find((reaction) => reaction.emoji === selectedEmoji)
+    ? visibleReactions.find((reaction) => reaction.emoji === selectedEmoji)
     : null;
 
   const hoveredUsers = hoveredReaction
@@ -181,12 +182,12 @@ export const MessageReactions = ({
     []
   );
 
-  if (reactions.length === 0) return null;
+  if (visibleReactions.length === 0) return null;
 
   return (
     <>
       <div className="flex flex-wrap gap-1 mt-1">
-        {reactions.map((reaction) => {
+        {visibleReactions.map((reaction) => {
           const reactionTooltipId = `${tooltipId}-${reaction.emoji}`;
 
           return (
@@ -234,7 +235,7 @@ export const MessageReactions = ({
 
       {selectedReaction && reactionSource && (
         <MessageReactionUsersModal
-          reactions={reactions}
+          reactions={visibleReactions}
           selectedReaction={selectedReaction}
           users={reactionUsers}
           reactionUserMap={reactionUserMap}

--- a/apps/harmonie/src/shared/notifications/PushNotificationContext.test.tsx
+++ b/apps/harmonie/src/shared/notifications/PushNotificationContext.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PushNotificationProvider } from './PushNotificationContext';
+import type { PushNotificationStatus } from './webPush';
+
+const mocks = vi.hoisted(() => ({
+  dismissPrompt: vi.fn(),
+  enable: vi.fn(),
+  getInitialStatus: vi.fn<() => PushNotificationStatus>(),
+  getPromptDismissed: vi.fn(),
+  isAuthenticated: true,
+  resync: vi.fn<() => Promise<PushNotificationStatus>>(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/features/auth/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated: mocks.isAuthenticated }),
+}));
+
+vi.mock('./webPush', () => ({
+  disableWebPushNotificationsLocally: vi.fn(),
+  enableWebPushNotifications: mocks.enable,
+  getInitialPushNotificationStatus: mocks.getInitialStatus,
+  getPushNotificationsPromptDismissed: mocks.getPromptDismissed,
+  resyncWebPushNotifications: mocks.resync,
+  setPushNotificationsPromptDismissed: mocks.dismissPrompt,
+}));
+
+describe('PushNotificationProvider', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+    mocks.dismissPrompt.mockReset();
+    mocks.enable.mockReset();
+    mocks.getInitialStatus.mockReset();
+    mocks.getPromptDismissed.mockReset();
+    mocks.resync.mockReset();
+    mocks.isAuthenticated = true;
+    mocks.getInitialStatus.mockReturnValue('prompt');
+    mocks.getPromptDismissed.mockReturnValue(false);
+    mocks.resync.mockResolvedValue('prompt');
+    mocks.enable.mockResolvedValue('enabled');
+  });
+
+  it('shows and dismisses the soft prompt for authenticated users', () => {
+    render(
+      <PushNotificationProvider>
+        <div>app</div>
+      </PushNotificationProvider>
+    );
+
+    expect(screen.getByText('notifications.push.promptTitle')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'notifications.push.dismiss' }));
+
+    expect(mocks.dismissPrompt).toHaveBeenCalledWith(true);
+    expect(screen.queryByText('notifications.push.promptTitle')).not.toBeInTheDocument();
+  });
+
+  it('enables push notifications from the soft prompt', async () => {
+    render(
+      <PushNotificationProvider>
+        <div>app</div>
+      </PushNotificationProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'notifications.push.enable' }));
+
+    await waitFor(() => expect(mocks.enable).toHaveBeenCalledOnce());
+    await waitFor(() =>
+      expect(screen.queryByText('notifications.push.promptTitle')).not.toBeInTheDocument()
+    );
+  });
+});

--- a/apps/harmonie/src/shared/notifications/PushNotificationContext.test.tsx
+++ b/apps/harmonie/src/shared/notifications/PushNotificationContext.test.tsx
@@ -84,4 +84,19 @@ describe('PushNotificationProvider', () => {
       expect(screen.queryByText('notifications.push.promptTitle')).not.toBeInTheDocument()
     );
   });
+
+  it('keeps the soft prompt open with feedback when setup fails', async () => {
+    mocks.enable.mockRejectedValueOnce(new Error('setup failed'));
+
+    render(
+      <PushNotificationProvider>
+        <div>app</div>
+      </PushNotificationProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'notifications.push.enable' }));
+
+    expect(await screen.findByText('notifications.push.error')).toBeInTheDocument();
+    expect(screen.getByText('notifications.push.promptTitle')).toBeInTheDocument();
+  });
 });

--- a/apps/harmonie/src/shared/notifications/PushNotificationContext.tsx
+++ b/apps/harmonie/src/shared/notifications/PushNotificationContext.tsx
@@ -79,7 +79,7 @@ export const PushNotificationProvider = ({ children }: { children: ReactNode }) 
 
   const showPrompt =
     isAuthenticated &&
-    (status === 'prompt' || status === 'syncing') &&
+    (status === 'prompt' || status === 'syncing' || status === 'error') &&
     !promptDismissed &&
     typeof window !== 'undefined';
 

--- a/apps/harmonie/src/shared/notifications/PushNotificationContext.tsx
+++ b/apps/harmonie/src/shared/notifications/PushNotificationContext.tsx
@@ -1,0 +1,109 @@
+import { createContext, use, useEffect, useState, type ReactNode } from 'react';
+import { useAuth } from '@/features/auth/AuthContext';
+import {
+  disableWebPushNotificationsLocally,
+  enableWebPushNotifications,
+  getInitialPushNotificationStatus,
+  getPushNotificationsPromptDismissed,
+  resyncWebPushNotifications,
+  setPushNotificationsPromptDismissed,
+  type PushNotificationStatus,
+} from './webPush';
+import { PushNotificationPrompt } from './PushNotificationPrompt';
+
+interface PushNotificationContextValue {
+  status: PushNotificationStatus;
+  promptDismissed: boolean;
+  showPrompt: boolean;
+  enable: () => Promise<void>;
+  disable: () => Promise<void>;
+  dismissPrompt: () => void;
+}
+
+const PushNotificationContext = createContext<PushNotificationContextValue>({
+  status: 'unsupported',
+  promptDismissed: true,
+  showPrompt: false,
+  enable: async () => {},
+  disable: async () => {},
+  dismissPrompt: () => {},
+});
+
+export const PushNotificationProvider = ({ children }: { children: ReactNode }) => {
+  const { isAuthenticated } = useAuth();
+  const [status, setStatus] = useState<PushNotificationStatus>(() =>
+    getInitialPushNotificationStatus()
+  );
+  const [promptDismissed, setPromptDismissed] = useState(() =>
+    getPushNotificationsPromptDismissed()
+  );
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    let cancelled = false;
+
+    const sync = async () => {
+      const nextStatus = await resyncWebPushNotifications().catch(() => 'error' as const);
+      if (!cancelled) setStatus(nextStatus);
+    };
+
+    void sync();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated]);
+
+  const enable = async () => {
+    setStatus('syncing');
+    const nextStatus = await enableWebPushNotifications().catch(() => 'error' as const);
+    setStatus(nextStatus);
+    if (nextStatus === 'enabled') {
+      setPromptDismissed(false);
+      return;
+    }
+
+    throw new Error(nextStatus);
+  };
+
+  const disable = async () => {
+    setStatus('syncing');
+    const nextStatus = await disableWebPushNotificationsLocally().catch(() => 'error' as const);
+    setStatus(nextStatus);
+  };
+
+  const dismissPrompt = () => {
+    setPushNotificationsPromptDismissed(true);
+    setPromptDismissed(true);
+  };
+
+  const showPrompt =
+    isAuthenticated &&
+    (status === 'prompt' || status === 'syncing') &&
+    !promptDismissed &&
+    typeof window !== 'undefined';
+
+  const value = {
+    status,
+    promptDismissed,
+    showPrompt,
+    enable,
+    disable,
+    dismissPrompt,
+  };
+
+  return (
+    <PushNotificationContext.Provider value={value}>
+      {children}
+      {showPrompt && (
+        <PushNotificationPrompt
+          isLoading={status === 'syncing'}
+          onDismiss={dismissPrompt}
+          onEnable={enable}
+        />
+      )}
+    </PushNotificationContext.Provider>
+  );
+};
+
+export const usePushNotifications = () => use(PushNotificationContext);

--- a/apps/harmonie/src/shared/notifications/PushNotificationPrompt.tsx
+++ b/apps/harmonie/src/shared/notifications/PushNotificationPrompt.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { Bell, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Button, IconButton } from '@harmonie/ui';
+
+interface PushNotificationPromptProps {
+  isLoading: boolean;
+  onEnable: () => Promise<void>;
+  onDismiss: () => void;
+}
+
+export const PushNotificationPrompt = ({
+  isLoading,
+  onDismiss,
+  onEnable,
+}: PushNotificationPromptProps) => {
+  const { t } = useTranslation();
+  const [error, setError] = useState(false);
+
+  const handleEnable = async () => {
+    setError(false);
+    await onEnable().catch(() => setError(true));
+  };
+
+  return (
+    <div className="pointer-events-none fixed inset-x-3 bottom-[calc(0.75rem+env(safe-area-inset-bottom))] z-50 flex justify-center sm:inset-x-auto sm:right-4 sm:bottom-4">
+      <div className="pointer-events-auto flex w-full max-w-105 items-center gap-3 rounded-lg border border-secondary bg-surface-1 p-3 shadow-[0_8px_32px_rgba(61,53,48,0.18)]">
+        <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary text-primary-fg">
+          <Bell size={18} />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-text-1">{t('notifications.push.promptTitle')}</p>
+          <p className="text-xs leading-snug text-text-2">
+            {error ? t('notifications.push.error') : t('notifications.push.promptDescription')}
+          </p>
+        </div>
+
+        <Button size="small" onClick={handleEnable} isLoading={isLoading} className="shrink-0">
+          {t('notifications.push.enable')}
+        </Button>
+
+        <IconButton
+          size="small"
+          variant="ghost"
+          onClick={onDismiss}
+          title={t('notifications.push.dismiss')}
+          className="shrink-0"
+        >
+          <X size={16} />
+        </IconButton>
+      </div>
+    </div>
+  );
+};

--- a/apps/harmonie/src/shared/notifications/browserNotification.test.ts
+++ b/apps/harmonie/src/shared/notifications/browserNotification.test.ts
@@ -1,9 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  NOTIFICATION_NAVIGATE_EVENT,
-  requestBrowserNotificationPermission,
-  showBrowserNotification,
-} from './browserNotification';
+import { NOTIFICATION_NAVIGATE_EVENT, showBrowserNotification } from './browserNotification';
 
 vi.mock('@/i18n', () => ({
   default: {
@@ -31,7 +27,6 @@ interface NotificationOptions {
 
 class MockNotification {
   static permission: NotificationPermission = 'default';
-  static requestPermission = vi.fn();
   static instances: MockNotification[] = [];
 
   onclick: (() => void) | null = null;
@@ -48,17 +43,8 @@ class MockNotification {
 describe('browserNotification', () => {
   beforeEach(() => {
     MockNotification.permission = 'default';
-    MockNotification.requestPermission.mockReset();
     MockNotification.instances = [];
     vi.stubGlobal('Notification', MockNotification);
-  });
-
-  it('requests permission only when notifications are undecided', () => {
-    MockNotification.requestPermission.mockResolvedValueOnce('granted');
-
-    requestBrowserNotificationPermission();
-
-    expect(MockNotification.requestPermission).toHaveBeenCalledOnce();
   });
 
   it('shows a browser notification when permission is granted', () => {

--- a/apps/harmonie/src/shared/notifications/browserNotification.ts
+++ b/apps/harmonie/src/shared/notifications/browserNotification.ts
@@ -29,13 +29,6 @@ const buildNotificationTitle = (payload: BrowserNotificationPayload): string => 
   });
 };
 
-export const requestBrowserNotificationPermission = () => {
-  if (typeof window === 'undefined' || !('Notification' in window)) return;
-  if (Notification.permission !== 'default') return;
-
-  void Notification.requestPermission().catch(() => {});
-};
-
 export const showBrowserNotification = (payload: BrowserNotificationPayload) => {
   if (typeof window === 'undefined' || !('Notification' in window)) return;
   if (Notification.permission !== 'granted') return;

--- a/apps/harmonie/src/shared/notifications/webPush.test.ts
+++ b/apps/harmonie/src/shared/notifications/webPush.test.ts
@@ -66,6 +66,52 @@ describe('webPush', () => {
     expect(getInitialPushNotificationStatus()).toBe('denied');
   });
 
+  it('persists and clears soft-prompt dismissal', async () => {
+    const { getPushNotificationsPromptDismissed, setPushNotificationsPromptDismissed } =
+      await import('./webPush');
+
+    expect(getPushNotificationsPromptDismissed()).toBe(false);
+
+    setPushNotificationsPromptDismissed(true);
+    expect(getPushNotificationsPromptDismissed()).toBe(true);
+
+    setPushNotificationsPromptDismissed(false);
+    expect(getPushNotificationsPromptDismissed()).toBe(false);
+  });
+
+  it('reports prompt, enabled, and disabled states from the local preference', async () => {
+    setNotificationPermission('default');
+    setWebPushSupport({} as ServiceWorkerRegistration);
+    const { getInitialPushNotificationStatus } = await import('./webPush');
+
+    expect(getInitialPushNotificationStatus()).toBe('prompt');
+
+    setNotificationPermission('granted');
+    expect(getInitialPushNotificationStatus()).toBe('disabled');
+
+    localStorage.setItem('harmonie-push-notifications-enabled', 'true');
+
+    expect(getInitialPushNotificationStatus()).toBe('enabled');
+  });
+
+  it('handles unsupported, denied, and dismissed permission outcomes', async () => {
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: false,
+    });
+    const { enableWebPushNotifications } = await import('./webPush');
+
+    await expect(enableWebPushNotifications()).resolves.toBe('unsupported');
+
+    setNotificationPermission('denied');
+    setWebPushSupport({} as ServiceWorkerRegistration);
+    await expect(enableWebPushNotifications()).resolves.toBe('denied');
+
+    setNotificationPermission('default', vi.fn().mockResolvedValue('default'));
+    await expect(enableWebPushNotifications()).resolves.toBe('disabled');
+    expect(apiMocks.getWebPushPublicKey).not.toHaveBeenCalled();
+  });
+
   it('subscribes and registers the device when enabled', async () => {
     const requestPermission = vi.fn().mockResolvedValue('granted');
     const subscriptionJson = {
@@ -87,6 +133,7 @@ describe('webPush', () => {
     } as unknown as ServiceWorkerRegistration;
     setNotificationPermission('default', requestPermission);
     setWebPushSupport(registration);
+    vi.mocked(navigator.serviceWorker.getRegistration).mockResolvedValue(undefined);
     apiMocks.getWebPushPublicKey.mockResolvedValue({ publicKey: 'AQAB' });
     apiMocks.registerWebPushSubscription.mockResolvedValue(undefined);
     const { enableWebPushNotifications } = await import('./webPush');
@@ -100,6 +147,81 @@ describe('webPush', () => {
     });
     expect(apiMocks.registerWebPushSubscription).toHaveBeenCalledWith(subscriptionJson);
     expect(localStorage.getItem('harmonie-push-notifications-enabled')).toBe('true');
+  });
+
+  it('reuses an existing service worker registration and subscription', async () => {
+    const subscriptionJson = {
+      endpoint: 'https://push.example/existing-subscription',
+      expirationTime: null,
+      keys: { p256dh: 'existing-p256dh', auth: 'existing-auth' },
+    };
+    const subscription = { toJSON: vi.fn(() => subscriptionJson) };
+    const subscribe = vi.fn();
+    const registration = {
+      pushManager: {
+        getSubscription: vi.fn().mockResolvedValue(subscription),
+        subscribe,
+      },
+    } as unknown as ServiceWorkerRegistration;
+    setNotificationPermission('granted');
+    setWebPushSupport(registration);
+    apiMocks.getWebPushPublicKey.mockResolvedValue({ publicKey: 'AQAB' });
+    apiMocks.registerWebPushSubscription.mockResolvedValue(undefined);
+    const { enableWebPushNotifications } = await import('./webPush');
+
+    await expect(enableWebPushNotifications()).resolves.toBe('enabled');
+
+    expect(navigator.serviceWorker.register).not.toHaveBeenCalled();
+    expect(subscribe).not.toHaveBeenCalled();
+    expect(apiMocks.registerWebPushSubscription).toHaveBeenCalledWith(subscriptionJson);
+  });
+
+  it('resyncs only an enabled and permitted preference', async () => {
+    localStorage.setItem('harmonie-push-notifications-enabled', 'true');
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: false,
+    });
+    const { resyncWebPushNotifications } = await import('./webPush');
+
+    await expect(resyncWebPushNotifications()).resolves.toBe('unsupported');
+
+    setNotificationPermission('denied');
+    setWebPushSupport({} as ServiceWorkerRegistration);
+
+    await expect(resyncWebPushNotifications()).resolves.toBe('denied');
+
+    localStorage.removeItem('harmonie-push-notifications-enabled');
+    setNotificationPermission('granted');
+
+    await expect(resyncWebPushNotifications()).resolves.toBe('disabled');
+    expect(apiMocks.getWebPushPublicKey).not.toHaveBeenCalled();
+  });
+
+  it('restores a previously enabled subscription during resync', async () => {
+    const subscription = {
+      toJSON: vi.fn(() => ({
+        endpoint: 'https://push.example/resynced-subscription',
+        expirationTime: null,
+        keys: { p256dh: 'resynced-p256dh', auth: 'resynced-auth' },
+      })),
+    };
+    const registration = {
+      pushManager: {
+        getSubscription: vi.fn().mockResolvedValue(subscription),
+        subscribe: vi.fn(),
+      },
+    } as unknown as ServiceWorkerRegistration;
+    localStorage.setItem('harmonie-push-notifications-enabled', 'true');
+    setNotificationPermission('granted');
+    setWebPushSupport(registration);
+    apiMocks.getWebPushPublicKey.mockResolvedValue({ publicKey: 'AQAB' });
+    apiMocks.registerWebPushSubscription.mockResolvedValue(undefined);
+    const { resyncWebPushNotifications } = await import('./webPush');
+
+    await expect(resyncWebPushNotifications()).resolves.toBe('enabled');
+
+    expect(apiMocks.registerWebPushSubscription).toHaveBeenCalledWith(subscription.toJSON());
   });
 
   it('unsubscribes locally when disabled', async () => {

--- a/apps/harmonie/src/shared/notifications/webPush.test.ts
+++ b/apps/harmonie/src/shared/notifications/webPush.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const apiMocks = vi.hoisted(() => ({
+  getWebPushPublicKey: vi.fn(),
+  registerWebPushSubscription: vi.fn(),
+}));
+
+vi.mock('@/api/notifications', () => ({
+  getWebPushPublicKey: apiMocks.getWebPushPublicKey,
+  registerWebPushSubscription: apiMocks.registerWebPushSubscription,
+}));
+
+const setNotificationPermission = (
+  permission: NotificationPermission,
+  requestPermission = vi.fn<() => Promise<NotificationPermission>>()
+) => {
+  Object.defineProperty(window, 'Notification', {
+    configurable: true,
+    value: {
+      permission,
+      requestPermission,
+    },
+  });
+};
+
+const setWebPushSupport = (registration: ServiceWorkerRegistration) => {
+  Object.defineProperty(window, 'isSecureContext', {
+    configurable: true,
+    value: true,
+  });
+  Object.defineProperty(window, 'PushManager', {
+    configurable: true,
+    value: vi.fn(),
+  });
+  Object.defineProperty(navigator, 'serviceWorker', {
+    configurable: true,
+    value: {
+      getRegistration: vi.fn().mockResolvedValue(registration),
+      register: vi.fn().mockResolvedValue(registration),
+    },
+  });
+};
+
+describe('webPush', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    Object.values(apiMocks).forEach((mock) => mock.mockReset());
+  });
+
+  it('reports unsupported browsers', async () => {
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: false,
+    });
+    const { getInitialPushNotificationStatus, isWebPushSupported } = await import('./webPush');
+
+    expect(isWebPushSupported()).toBe(false);
+    expect(getInitialPushNotificationStatus()).toBe('unsupported');
+  });
+
+  it('reports denied browser permissions', async () => {
+    setNotificationPermission('denied');
+    setWebPushSupport({} as ServiceWorkerRegistration);
+    const { getInitialPushNotificationStatus } = await import('./webPush');
+
+    expect(getInitialPushNotificationStatus()).toBe('denied');
+  });
+
+  it('subscribes and registers the device when enabled', async () => {
+    const requestPermission = vi.fn().mockResolvedValue('granted');
+    const subscriptionJson = {
+      endpoint: 'https://push.example/subscription',
+      expirationTime: null,
+      keys: {
+        p256dh: 'p256dh-key',
+        auth: 'auth-key',
+      },
+    };
+    const subscription = {
+      toJSON: vi.fn(() => subscriptionJson),
+    };
+    const registration = {
+      pushManager: {
+        getSubscription: vi.fn().mockResolvedValue(null),
+        subscribe: vi.fn().mockResolvedValue(subscription),
+      },
+    } as unknown as ServiceWorkerRegistration;
+    setNotificationPermission('default', requestPermission);
+    setWebPushSupport(registration);
+    apiMocks.getWebPushPublicKey.mockResolvedValue({ publicKey: 'AQAB' });
+    apiMocks.registerWebPushSubscription.mockResolvedValue(undefined);
+    const { enableWebPushNotifications } = await import('./webPush');
+
+    await expect(enableWebPushNotifications()).resolves.toBe('enabled');
+
+    expect(requestPermission).toHaveBeenCalledOnce();
+    expect(registration.pushManager.subscribe).toHaveBeenCalledWith({
+      userVisibleOnly: true,
+      applicationServerKey: expect.any(Uint8Array),
+    });
+    expect(apiMocks.registerWebPushSubscription).toHaveBeenCalledWith(subscriptionJson);
+    expect(localStorage.getItem('harmonie-push-notifications-enabled')).toBe('true');
+  });
+
+  it('unsubscribes locally when disabled', async () => {
+    const unsubscribe = vi.fn().mockResolvedValue(true);
+    const registration = {
+      pushManager: {
+        getSubscription: vi.fn().mockResolvedValue({ unsubscribe }),
+      },
+    } as unknown as ServiceWorkerRegistration;
+    setNotificationPermission('granted');
+    setWebPushSupport(registration);
+    localStorage.setItem('harmonie-push-notifications-enabled', 'true');
+    const { disableWebPushNotificationsLocally } = await import('./webPush');
+
+    await expect(disableWebPushNotificationsLocally()).resolves.toBe('disabled');
+
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(localStorage.getItem('harmonie-push-notifications-enabled')).toBeNull();
+  });
+});

--- a/apps/harmonie/src/shared/notifications/webPush.ts
+++ b/apps/harmonie/src/shared/notifications/webPush.ts
@@ -1,0 +1,121 @@
+import { getWebPushPublicKey, registerWebPushSubscription } from '@/api/notifications';
+
+const PUSH_NOTIFICATIONS_ENABLED_KEY = 'harmonie-push-notifications-enabled';
+const PUSH_NOTIFICATIONS_PROMPT_DISMISSED_KEY = 'harmonie-push-notifications-prompt-dismissed';
+
+export type PushNotificationStatus =
+  | 'unsupported'
+  | 'disabled'
+  | 'prompt'
+  | 'enabled'
+  | 'denied'
+  | 'syncing'
+  | 'error';
+
+export const isWebPushSupported = () =>
+  typeof window !== 'undefined' &&
+  window.isSecureContext &&
+  'Notification' in window &&
+  'serviceWorker' in navigator &&
+  'PushManager' in window;
+
+const getPushNotificationsEnabledPreference = () =>
+  localStorage.getItem(PUSH_NOTIFICATIONS_ENABLED_KEY) === 'true';
+
+const setPushNotificationsEnabledPreference = (enabled: boolean) => {
+  if (enabled) {
+    localStorage.setItem(PUSH_NOTIFICATIONS_ENABLED_KEY, 'true');
+    return;
+  }
+
+  localStorage.removeItem(PUSH_NOTIFICATIONS_ENABLED_KEY);
+};
+
+export const getPushNotificationsPromptDismissed = () =>
+  localStorage.getItem(PUSH_NOTIFICATIONS_PROMPT_DISMISSED_KEY) === 'true';
+
+export const setPushNotificationsPromptDismissed = (dismissed: boolean) => {
+  if (dismissed) {
+    localStorage.setItem(PUSH_NOTIFICATIONS_PROMPT_DISMISSED_KEY, 'true');
+    return;
+  }
+
+  localStorage.removeItem(PUSH_NOTIFICATIONS_PROMPT_DISMISSED_KEY);
+};
+
+export const getInitialPushNotificationStatus = (): PushNotificationStatus => {
+  if (!isWebPushSupported()) return 'unsupported';
+  if (Notification.permission === 'denied') return 'denied';
+  if (getPushNotificationsEnabledPreference()) return 'enabled';
+  if (Notification.permission === 'default') return 'prompt';
+  return 'disabled';
+};
+
+const urlBase64ToUint8Array = (base64String: string) => {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = `${base64String}${padding}`.replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = window.atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+
+  for (let i = 0; i < rawData.length; i += 1) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+
+  return outputArray;
+};
+
+const ensureServiceWorkerRegistration = async () => {
+  const existingRegistration = await navigator.serviceWorker.getRegistration('/');
+  if (existingRegistration) return existingRegistration;
+  return navigator.serviceWorker.register('/sw.js');
+};
+
+const getCurrentPushSubscription = async () => {
+  if (!isWebPushSupported()) return null;
+  const registration = await navigator.serviceWorker.getRegistration('/');
+  if (!registration) return null;
+  return registration.pushManager.getSubscription();
+};
+
+export const enableWebPushNotifications = async () => {
+  if (!isWebPushSupported()) return 'unsupported' as const;
+
+  const permission =
+    Notification.permission === 'default'
+      ? await Notification.requestPermission()
+      : Notification.permission;
+  if (permission === 'denied') return 'denied' as const;
+  if (permission !== 'granted') return 'disabled' as const;
+
+  const [{ publicKey }, registration] = await Promise.all([
+    getWebPushPublicKey(),
+    ensureServiceWorkerRegistration(),
+  ]);
+  const existingSubscription = await registration.pushManager.getSubscription();
+  const subscription =
+    existingSubscription ??
+    (await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(publicKey),
+    }));
+
+  await registerWebPushSubscription(subscription.toJSON());
+  setPushNotificationsEnabledPreference(true);
+  setPushNotificationsPromptDismissed(false);
+
+  return 'enabled' as const;
+};
+
+export const resyncWebPushNotifications = async () => {
+  if (!getPushNotificationsEnabledPreference()) return getInitialPushNotificationStatus();
+  if (!isWebPushSupported()) return 'unsupported' as const;
+  if (Notification.permission !== 'granted') return getInitialPushNotificationStatus();
+  return enableWebPushNotifications();
+};
+
+export const disableWebPushNotificationsLocally = async () => {
+  const subscription = await getCurrentPushSubscription();
+  await subscription?.unsubscribe();
+  setPushNotificationsEnabledPreference(false);
+  return getInitialPushNotificationStatus();
+};

--- a/doctor.config.json
+++ b/doctor.config.json
@@ -7,7 +7,8 @@
       "**/*.spec.ts",
       "**/*.spec.tsx",
       "**/__tests__/**",
-      "**/src/test/**"
+      "**/src/test/**",
+      "**/.vite/**"
     ]
   }
 }


### PR DESCRIPTION
## Summary

- add Web Push subscription through the VAPID public key and device registration APIs
- add a notification provider with permission handling, subscription resync, logout cleanup, and persisted local preferences
- add a translated soft prompt and a notification section in user settings
- handle push payload display and route navigation from the service worker
- keep realtime browser notifications as a fallback while preventing duplicates when Web Push is enabled
- normalize partial message payloads and stabilize message-thread scrolling included in the original branch

## Backend dependencies

Uses the notification endpoints and payload contract already merged in Harmonie-chat/harmonie-server#416, Harmonie-chat/harmonie-server#418, Harmonie-chat/harmonie-server#421, and Harmonie-chat/harmonie-server#426.

Production delivery still requires the backend VAPID configuration and notification worker to be running.

## Review

- rebased on the latest `main`
- reviewed the complete branch diff and backend payload/API contracts
- fixed duplicate notifications caused by realtime browser notifications and service-worker push notifications being active simultaneously
- no remaining blocking issue found in the client implementation

## Validation

- `pnpm test` — 583 app tests and 148 UI tests passed
- `pnpm --filter @harmonie/app test:coverage` — 80.13% branch coverage
- `pnpm lint`
- `pnpm test:typecheck`
- `pnpm build`
- `pnpm format:check`
- `pnpm doctor`

A final manual validation with a production-like HTTPS origin, configured VAPID keys, and the notification worker is still recommended to verify delivery while the app is closed and notification-click navigation.