### PR TITLE
fix: store refresh tokens in HttpOnly cookies

### DIFF
--- a/apps/harmonie/src/api/auth.test.ts
+++ b/apps/harmonie/src/api/auth.test.ts
@@ -63,21 +63,14 @@ describe('auth api', () => {
     });
     await logout();
 
-    const emptyRefreshTokenBody = JSON.stringify({ refreshToken: '' });
     expect(fetchMock).toHaveBeenNthCalledWith(1, `${API_BASE}/auth/refresh`, {
       method: 'POST',
       credentials: 'include',
-      headers: { 'Content-Type': 'application/json' },
-      body: emptyRefreshTokenBody,
     });
     expect(fetchMock).toHaveBeenNthCalledWith(2, `${API_BASE}/auth/logout`, {
       method: 'POST',
       credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: 'Bearer access-token',
-      },
-      body: emptyRefreshTokenBody,
+      headers: { Authorization: 'Bearer access-token' },
     });
   });
 

--- a/apps/harmonie/src/api/auth.test.ts
+++ b/apps/harmonie/src/api/auth.test.ts
@@ -1,22 +1,25 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearTokens, storeTokens } from './authStorage';
 
 const API_BASE = 'https://localhost:5000/api';
+const FUTURE_EXPIRATION = '2100-01-01T00:00:00.000Z';
 
 describe('auth api', () => {
   beforeEach(() => {
+    clearTokens();
     vi.stubGlobal('fetch', vi.fn());
   });
 
-  it('logs in and registers with JSON bodies', async () => {
+  it('logs in and registers with credentialed JSON requests', async () => {
     const fetchMock = vi.mocked(fetch);
     fetchMock
-      .mockResolvedValueOnce(Response.json({ accessToken: 'a', refreshToken: 'r' }))
+      .mockResolvedValueOnce(Response.json({ accessToken: 'a', expiresAt: FUTURE_EXPIRATION }))
       .mockResolvedValueOnce(Response.json({ userId: 'user-1' }));
     const { login, register } = await import('./auth');
 
     await expect(login({ emailOrUsername: 'a@b.com', password: 'Password1!' })).resolves.toEqual({
       accessToken: 'a',
-      refreshToken: 'r',
+      expiresAt: FUTURE_EXPIRATION,
     });
     await register({
       avatar: { bg: null, color: null, icon: null },
@@ -28,11 +31,13 @@ describe('auth api', () => {
 
     expect(fetchMock).toHaveBeenNthCalledWith(1, `${API_BASE}/auth/login`, {
       method: 'POST',
+      credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ emailOrUsername: 'a@b.com', password: 'Password1!' }),
     });
     expect(fetchMock).toHaveBeenNthCalledWith(2, `${API_BASE}/auth/register`, {
       method: 'POST',
+      credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         avatar: { bg: null, color: null, icon: null },
@@ -44,28 +49,35 @@ describe('auth api', () => {
     });
   });
 
-  it('refreshes and logs out', async () => {
+  it('refreshes and logs out with the HttpOnly cookie', async () => {
     const fetchMock = vi.mocked(fetch);
     fetchMock
-      .mockResolvedValueOnce(Response.json({ accessToken: 'new', refreshToken: 'next' }))
+      .mockResolvedValueOnce(Response.json({ accessToken: 'new', expiresAt: FUTURE_EXPIRATION }))
       .mockResolvedValueOnce(new Response(null, { status: 204 }));
+    storeTokens({ accessToken: 'access-token', expiresAt: FUTURE_EXPIRATION });
     const { logout, refreshTokens } = await import('./auth');
 
-    await expect(refreshTokens({ refreshToken: 'refresh' })).resolves.toEqual({
+    await expect(refreshTokens()).resolves.toEqual({
       accessToken: 'new',
-      refreshToken: 'next',
+      expiresAt: FUTURE_EXPIRATION,
     });
-    await logout({ refreshToken: 'refresh' });
+    await logout();
 
+    const emptyRefreshTokenBody = JSON.stringify({ refreshToken: '' });
     expect(fetchMock).toHaveBeenNthCalledWith(1, `${API_BASE}/auth/refresh`, {
       method: 'POST',
+      credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ refreshToken: 'refresh' }),
+      body: emptyRefreshTokenBody,
     });
     expect(fetchMock).toHaveBeenNthCalledWith(2, `${API_BASE}/auth/logout`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ refreshToken: 'refresh' }),
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer access-token',
+      },
+      body: emptyRefreshTokenBody,
     });
   });
 

--- a/apps/harmonie/src/api/auth.ts
+++ b/apps/harmonie/src/api/auth.ts
@@ -1,18 +1,19 @@
+import { getAccessToken } from './authStorage';
 import type {
   LoginRequest,
   LoginResponse,
-  LogoutRequest,
-  RefreshRequest,
   RefreshResponse,
   RegisterRequest,
   RegisterResponse,
 } from '@/types/auth';
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL;
+const EMPTY_REFRESH_TOKEN_BODY = JSON.stringify({ refreshToken: '' });
 
 export const login = async (body: LoginRequest): Promise<LoginResponse> => {
   const response = await fetch(`${API_BASE}/auth/login`, {
     method: 'POST',
+    credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
@@ -27,6 +28,7 @@ export const login = async (body: LoginRequest): Promise<LoginResponse> => {
 export const register = async (body: RegisterRequest): Promise<RegisterResponse> => {
   const response = await fetch(`${API_BASE}/auth/register`, {
     method: 'POST',
+    credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
@@ -38,11 +40,12 @@ export const register = async (body: RegisterRequest): Promise<RegisterResponse>
   return response.json();
 };
 
-export const refreshTokens = async (body: RefreshRequest): Promise<RefreshResponse> => {
+export const refreshTokens = async (): Promise<RefreshResponse> => {
   const response = await fetch(`${API_BASE}/auth/refresh`, {
     method: 'POST',
+    credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
+    body: EMPTY_REFRESH_TOKEN_BODY,
   });
 
   if (!response.ok) {
@@ -52,10 +55,15 @@ export const refreshTokens = async (body: RefreshRequest): Promise<RefreshRespon
   return response.json();
 };
 
-export const logout = async (body: LogoutRequest): Promise<void> => {
+export const logout = async (): Promise<void> => {
+  const accessToken = getAccessToken();
   await fetch(`${API_BASE}/auth/logout`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+    },
+    body: EMPTY_REFRESH_TOKEN_BODY,
   });
 };

--- a/apps/harmonie/src/api/auth.ts
+++ b/apps/harmonie/src/api/auth.ts
@@ -8,7 +8,6 @@ import type {
 } from '@/types/auth';
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL;
-const EMPTY_REFRESH_TOKEN_BODY = JSON.stringify({ refreshToken: '' });
 
 export const login = async (body: LoginRequest): Promise<LoginResponse> => {
   const response = await fetch(`${API_BASE}/auth/login`, {
@@ -44,8 +43,6 @@ export const refreshTokens = async (): Promise<RefreshResponse> => {
   const response = await fetch(`${API_BASE}/auth/refresh`, {
     method: 'POST',
     credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
-    body: EMPTY_REFRESH_TOKEN_BODY,
   });
 
   if (!response.ok) {
@@ -60,10 +57,6 @@ export const logout = async (): Promise<void> => {
   await fetch(`${API_BASE}/auth/logout`, {
     method: 'POST',
     credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
-    },
-    body: EMPTY_REFRESH_TOKEN_BODY,
+    headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : undefined,
   });
 };

--- a/apps/harmonie/src/api/authStorage.test.ts
+++ b/apps/harmonie/src/api/authStorage.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   clearTokens,
+  discardLegacyRefreshToken,
   getAccessToken,
-  getRefreshToken,
   isAccessTokenExpiring,
   storeTokens,
   subscribeToTokenChanges,
@@ -15,23 +15,20 @@ describe('authStorage', () => {
     clearTokens();
   });
 
-  it('stores the access token and its expiration in memory and the refresh token in localStorage', () => {
+  it('stores the access token and its expiration in memory', () => {
     storeTokens({
       accessToken: 'access-token',
-      refreshToken: 'refresh-token',
       expiresAt: FUTURE_EXPIRATION,
     });
 
     expect(getAccessToken()).toBe('access-token');
     expect(isAccessTokenExpiring()).toBe(false);
-    expect(getRefreshToken()).toBe('refresh-token');
-    expect(localStorage.getItem('refreshToken')).toBe('refresh-token');
+    expect(localStorage.getItem('refreshToken')).toBeNull();
   });
 
-  it('clears both tokens and the access token expiration', () => {
+  it('clears the access token and its expiration', () => {
     storeTokens({
       accessToken: 'access-token',
-      refreshToken: 'refresh-token',
       expiresAt: FUTURE_EXPIRATION,
     });
 
@@ -39,13 +36,19 @@ describe('authStorage', () => {
 
     expect(getAccessToken()).toBeNull();
     expect(isAccessTokenExpiring()).toBe(true);
-    expect(getRefreshToken()).toBeNull();
+  });
+
+  it('removes refresh tokens left by older clients', () => {
+    localStorage.setItem('refreshToken', 'legacy-refresh-token');
+
+    discardLegacyRefreshToken();
+
+    expect(localStorage.getItem('refreshToken')).toBeNull();
   });
 
   it('detects access tokens that are expired or close to expiry', () => {
     storeTokens({
       accessToken: 'access-token',
-      refreshToken: 'refresh-token',
       expiresAt: '1970-01-01T00:02:10.000Z',
     });
 
@@ -58,7 +61,6 @@ describe('authStorage', () => {
 
     storeTokens({
       accessToken: 'access-token',
-      refreshToken: 'refresh-token',
       expiresAt: 'invalid-date',
     });
 
@@ -71,14 +73,12 @@ describe('authStorage', () => {
 
     storeTokens({
       accessToken: 'access-token',
-      refreshToken: 'refresh-token',
       expiresAt: FUTURE_EXPIRATION,
     });
     clearTokens();
     unsubscribe();
     storeTokens({
       accessToken: 'next-token',
-      refreshToken: 'next-refresh-token',
       expiresAt: FUTURE_EXPIRATION,
     });
 

--- a/apps/harmonie/src/api/authStorage.ts
+++ b/apps/harmonie/src/api/authStorage.ts
@@ -11,6 +11,7 @@ const notifyTokenChange = () => {
   tokenChangeListeners.forEach((listener) => listener(_accessToken));
 };
 
+// TODO(#203): Remove this migration after cookie-based auth has been in production for 30 days.
 export const discardLegacyRefreshToken = () => {
   localStorage.removeItem(LEGACY_REFRESH_TOKEN_KEY);
 };

--- a/apps/harmonie/src/api/authStorage.ts
+++ b/apps/harmonie/src/api/authStorage.ts
@@ -1,6 +1,6 @@
 import type { TokensPayload } from '@/types/auth';
 
-const REFRESH_TOKEN_KEY = 'refreshToken';
+const LEGACY_REFRESH_TOKEN_KEY = 'refreshToken';
 const ACCESS_TOKEN_EXPIRATION_BUFFER_MS = 30_000;
 
 let _accessToken: string | null = null;
@@ -11,10 +11,13 @@ const notifyTokenChange = () => {
   tokenChangeListeners.forEach((listener) => listener(_accessToken));
 };
 
+export const discardLegacyRefreshToken = () => {
+  localStorage.removeItem(LEGACY_REFRESH_TOKEN_KEY);
+};
+
 export const storeTokens = (response: TokensPayload) => {
   _accessToken = response.accessToken;
   _accessTokenExpiresAt = Date.parse(response.expiresAt);
-  localStorage.setItem(REFRESH_TOKEN_KEY, response.refreshToken);
   notifyTokenChange();
 };
 
@@ -28,8 +31,6 @@ export const isAccessTokenExpiring = (
   !Number.isFinite(_accessTokenExpiresAt) ||
   _accessTokenExpiresAt <= now + expirationBufferMs;
 
-export const getRefreshToken = () => localStorage.getItem(REFRESH_TOKEN_KEY);
-
 export const subscribeToTokenChanges = (listener: (accessToken: string | null) => void) => {
   tokenChangeListeners.add(listener);
   return () => {
@@ -40,6 +41,6 @@ export const subscribeToTokenChanges = (listener: (accessToken: string | null) =
 export const clearTokens = () => {
   _accessToken = null;
   _accessTokenExpiresAt = null;
-  localStorage.removeItem(REFRESH_TOKEN_KEY);
+  discardLegacyRefreshToken();
   notifyTokenChange();
 };

--- a/apps/harmonie/src/api/client.test.ts
+++ b/apps/harmonie/src/api/client.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { clearTokens, getAccessToken, getRefreshToken, storeTokens } from './authStorage';
+import { clearTokens, getAccessToken, storeTokens } from './authStorage';
 
 const refreshTokensMock = vi.fn();
 const FUTURE_EXPIRATION = '2100-01-01T00:00:00.000Z';
@@ -21,7 +21,6 @@ describe('apiFetch', () => {
     fetchMock.mockResolvedValueOnce(new Response('{}', { status: 200 }));
     storeTokens({
       accessToken: 'access-token',
-      refreshToken: 'refresh-token',
       expiresAt: FUTURE_EXPIRATION,
     });
     const { apiFetch } = await import('./client');
@@ -43,12 +42,10 @@ describe('apiFetch', () => {
       .mockResolvedValueOnce(new Response('{"ok":true}', { status: 200 }));
     refreshTokensMock.mockResolvedValueOnce({
       accessToken: 'new-access-token',
-      refreshToken: 'new-refresh-token',
       expiresAt: FUTURE_EXPIRATION,
     });
     storeTokens({
       accessToken: 'old-access-token',
-      refreshToken: 'refresh-token',
       expiresAt: FUTURE_EXPIRATION,
     });
     const { apiFetch } = await import('./client');
@@ -56,20 +53,18 @@ describe('apiFetch', () => {
     const response = await apiFetch('/channels');
 
     expect(response.status).toBe(200);
-    expect(refreshTokensMock).toHaveBeenCalledWith({ refreshToken: 'refresh-token' });
+    expect(refreshTokensMock).toHaveBeenCalledWith();
     expect(fetchMock).toHaveBeenNthCalledWith(2, '/channels', {
       headers: {
         Authorization: 'Bearer new-access-token',
       },
     });
     expect(getAccessToken()).toBe('new-access-token');
-    expect(getRefreshToken()).toBe('new-refresh-token');
   });
 
   it('returns the cached access token while it is still valid', async () => {
     storeTokens({
       accessToken: 'access-token',
-      refreshToken: 'refresh-token',
       expiresAt: FUTURE_EXPIRATION,
     });
     const { getFreshAccessToken } = await import('./client');
@@ -81,12 +76,10 @@ describe('apiFetch', () => {
   it('refreshes an expired access token before returning it to SignalR', async () => {
     refreshTokensMock.mockResolvedValueOnce({
       accessToken: 'fresh-access-token',
-      refreshToken: 'fresh-refresh-token',
       expiresAt: FUTURE_EXPIRATION,
     });
     storeTokens({
       accessToken: 'expired-access-token',
-      refreshToken: 'refresh-token',
       expiresAt: PAST_EXPIRATION,
     });
     const { getFreshAccessToken } = await import('./client');
@@ -96,9 +89,7 @@ describe('apiFetch', () => {
   });
 
   it('deduplicates concurrent refreshes across consumers', async () => {
-    let resolveRefresh:
-      | ((tokens: { accessToken: string; refreshToken: string; expiresAt: string }) => void)
-      | undefined;
+    let resolveRefresh: ((tokens: { accessToken: string; expiresAt: string }) => void) | undefined;
     refreshTokensMock.mockReturnValueOnce(
       new Promise((resolve) => {
         resolveRefresh = resolve;
@@ -106,7 +97,6 @@ describe('apiFetch', () => {
     );
     storeTokens({
       accessToken: 'expired-access-token',
-      refreshToken: 'refresh-token',
       expiresAt: PAST_EXPIRATION,
     });
     const { getFreshAccessToken, refreshAccessToken } = await import('./client');
@@ -115,7 +105,6 @@ describe('apiFetch', () => {
     const fromHttp = refreshAccessToken();
     resolveRefresh?.({
       accessToken: 'fresh-access-token',
-      refreshToken: 'new-refresh-token',
       expiresAt: FUTURE_EXPIRATION,
     });
 
@@ -131,7 +120,6 @@ describe('apiFetch', () => {
     fetchMock.mockResolvedValueOnce(new Response('{}', { status: 401 }));
     storeTokens({
       accessToken: 'access-token',
-      refreshToken: 'refresh-token',
       expiresAt: FUTURE_EXPIRATION,
     });
     const { apiFetch } = await import('./client');
@@ -152,7 +140,6 @@ describe('apiFetch', () => {
     refreshTokensMock.mockRejectedValueOnce(new Error('expired'));
     storeTokens({
       accessToken: 'access-token',
-      refreshToken: 'refresh-token',
       expiresAt: FUTURE_EXPIRATION,
     });
     const { apiFetch, setLogoutHandler } = await import('./client');
@@ -162,7 +149,6 @@ describe('apiFetch', () => {
 
     expect(onLogout).toHaveBeenCalledOnce();
     expect(getAccessToken()).toBeNull();
-    expect(getRefreshToken()).toBeNull();
   });
 });
 

--- a/apps/harmonie/src/api/client.ts
+++ b/apps/harmonie/src/api/client.ts
@@ -1,10 +1,4 @@
-import {
-  clearTokens,
-  getAccessToken,
-  getRefreshToken,
-  isAccessTokenExpiring,
-  storeTokens,
-} from './authStorage';
+import { clearTokens, getAccessToken, isAccessTokenExpiring, storeTokens } from './authStorage';
 import { refreshTokens } from './auth';
 
 let onLogout: (() => void) | null = null;
@@ -23,15 +17,8 @@ const withBearer = (init?: RequestInit): RequestInit => ({
 });
 
 const doRefresh = async (): Promise<string> => {
-  const refreshToken = getRefreshToken();
-  if (!refreshToken) {
-    clearTokens();
-    onLogout?.();
-    throw new Error('No refresh token is available');
-  }
-
   try {
-    const response = await refreshTokens({ refreshToken });
+    const response = await refreshTokens();
     storeTokens(response);
     return response.accessToken;
   } catch (error) {

--- a/apps/harmonie/src/features/auth/AuthContext.test.tsx
+++ b/apps/harmonie/src/features/auth/AuthContext.test.tsx
@@ -6,8 +6,9 @@ const mocks = vi.hoisted(() => ({
   logoutApi: vi.fn(),
   refreshTokens: vi.fn(),
   clearTokens: vi.fn(),
-  getRefreshToken: vi.fn(),
+  discardLegacyRefreshToken: vi.fn(),
   storeTokens: vi.fn(),
+  getFreshAccessToken: vi.fn(),
   setLogoutHandler: vi.fn(),
 }));
 
@@ -18,11 +19,12 @@ vi.mock('@/api/auth', () => ({
 
 vi.mock('@/api/authStorage', () => ({
   clearTokens: mocks.clearTokens,
-  getRefreshToken: mocks.getRefreshToken,
+  discardLegacyRefreshToken: mocks.discardLegacyRefreshToken,
   storeTokens: mocks.storeTokens,
 }));
 
 vi.mock('@/api/client', () => ({
+  getFreshAccessToken: mocks.getFreshAccessToken,
   setLogoutHandler: mocks.setLogoutHandler,
 }));
 
@@ -74,14 +76,15 @@ describe('AuthProvider', () => {
     });
   });
 
-  it('finishes initialization without a refresh token', async () => {
-    mocks.getRefreshToken.mockReturnValue(null);
+  it('finishes initialization without a refresh cookie', async () => {
+    mocks.refreshTokens.mockRejectedValueOnce({ code: 'VALIDATION_FAILED' });
 
     renderAuth();
 
     await waitFor(() => expect(screen.getByTestId('initializing')).toHaveTextContent('false'));
     expect(screen.getByTestId('authenticated')).toHaveTextContent('false');
-    expect(mocks.refreshTokens).not.toHaveBeenCalled();
+    expect(mocks.discardLegacyRefreshToken).toHaveBeenCalledOnce();
+    expect(mocks.refreshTokens).toHaveBeenCalledWith();
   });
 
   it('exposes inert defaults when used without a provider', async () => {
@@ -101,25 +104,23 @@ describe('AuthProvider', () => {
     expect(mocks.clearTokens).not.toHaveBeenCalled();
   });
 
-  it('refreshes tokens and authenticates when a refresh token exists', async () => {
-    mocks.getRefreshToken.mockReturnValue('refresh-token');
+  it('refreshes tokens and authenticates when a refresh cookie exists', async () => {
     mocks.refreshTokens.mockResolvedValueOnce({
       accessToken: 'access-token',
-      refreshToken: 'next-refresh-token',
+      expiresAt: '2100-01-01T00:00:00.000Z',
     });
 
     renderAuth();
 
     await waitFor(() => expect(screen.getByTestId('authenticated')).toHaveTextContent('true'));
-    expect(mocks.refreshTokens).toHaveBeenCalledWith({ refreshToken: 'refresh-token' });
+    expect(mocks.refreshTokens).toHaveBeenCalledWith();
     expect(mocks.storeTokens).toHaveBeenCalledWith({
       accessToken: 'access-token',
-      refreshToken: 'next-refresh-token',
+      expiresAt: '2100-01-01T00:00:00.000Z',
     });
   });
 
-  it('clears stored tokens for fatal refresh failures', async () => {
-    mocks.getRefreshToken.mockReturnValue('refresh-token');
+  it('clears access tokens for fatal refresh failures', async () => {
     mocks.refreshTokens.mockRejectedValueOnce({ code: 'AUTH_INVALID_REFRESH_TOKEN' });
 
     renderAuth();
@@ -130,7 +131,8 @@ describe('AuthProvider', () => {
   });
 
   it('exposes manual authentication and logout actions', async () => {
-    mocks.getRefreshToken.mockReturnValue('refresh-token');
+    mocks.refreshTokens.mockRejectedValueOnce({ code: 'VALIDATION_FAILED' });
+    mocks.getFreshAccessToken.mockResolvedValueOnce('access-token');
     mocks.logoutApi.mockRejectedValueOnce(new Error('already gone'));
 
     renderAuth();
@@ -145,13 +147,14 @@ describe('AuthProvider', () => {
       screen.getByRole('button', { name: 'Logout' }).click();
     });
 
-    expect(mocks.logoutApi).toHaveBeenCalledWith({ refreshToken: 'refresh-token' });
+    expect(mocks.getFreshAccessToken).toHaveBeenCalledOnce();
+    expect(mocks.logoutApi).toHaveBeenCalledWith();
     expect(mocks.clearTokens).toHaveBeenCalled();
     await waitFor(() => expect(screen.getByTestId('authenticated')).toHaveTextContent('false'));
   });
 
   it('registers a logout handler that clears local authentication state', async () => {
-    mocks.getRefreshToken.mockReturnValue(null);
+    mocks.refreshTokens.mockRejectedValueOnce({ code: 'VALIDATION_FAILED' });
 
     renderAuth();
     await waitFor(() => expect(mocks.setLogoutHandler).toHaveBeenCalledOnce());

--- a/apps/harmonie/src/features/auth/AuthContext.tsx
+++ b/apps/harmonie/src/features/auth/AuthContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, use, useEffect, useRef, useState, type ReactNode } from 'react';
 import { logout as logoutApi, refreshTokens } from '@/api/auth';
-import { clearTokens, getRefreshToken, storeTokens } from '@/api/authStorage';
-import { setLogoutHandler } from '@/api/client';
+import { clearTokens, discardLegacyRefreshToken, storeTokens } from '@/api/authStorage';
+import { getFreshAccessToken, setLogoutHandler } from '@/api/client';
 import type { ApiError } from '@/types/error';
 import { disableWebPushNotificationsLocally } from '@/shared/notifications/webPush';
 
@@ -44,29 +44,25 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     initialized.current = true;
 
     (async () => {
-      const refreshToken = getRefreshToken();
-      if (refreshToken) {
-        try {
-          const response = await refreshTokens({ refreshToken });
-          storeTokens(response);
-          setIsAuthenticated(true);
-        } catch (err) {
-          const apiError = err as ApiError;
-          if (FATAL_REFRESH_CODES.has(apiError?.code)) clearTokens();
-        }
+      discardLegacyRefreshToken();
+      try {
+        const response = await refreshTokens();
+        storeTokens(response);
+        setIsAuthenticated(true);
+      } catch (err) {
+        const apiError = err as ApiError;
+        if (FATAL_REFRESH_CODES.has(apiError?.code)) clearTokens();
       }
       setIsInitializing(false);
     })();
   }, []);
 
   const logout = async () => {
-    const refreshToken = getRefreshToken();
-    if (refreshToken) {
-      try {
-        await logoutApi({ refreshToken });
-      } catch (error) {
-        void error;
-      }
+    try {
+      await getFreshAccessToken();
+      await logoutApi();
+    } catch (error) {
+      void error;
     }
     await disableWebPushNotificationsLocally().catch(() => {});
     clearTokens();

--- a/apps/harmonie/src/features/auth/ConnectPage.test.tsx
+++ b/apps/harmonie/src/features/auth/ConnectPage.test.tsx
@@ -92,7 +92,7 @@ describe('ConnectPage', () => {
   it('logs in with username, stores tokens, authenticates, and navigates home', async () => {
     mocks.login.mockResolvedValueOnce({
       accessToken: 'access-token',
-      refreshToken: 'refresh-token',
+      expiresAt: '2100-01-01T00:00:00.000Z',
     });
     renderPage();
 
@@ -108,7 +108,7 @@ describe('ConnectPage', () => {
     );
     expect(mocks.storeTokens).toHaveBeenCalledWith({
       accessToken: 'access-token',
-      refreshToken: 'refresh-token',
+      expiresAt: '2100-01-01T00:00:00.000Z',
     });
     expect(mocks.setIsAuthenticated).toHaveBeenCalledWith(true);
     expect(mocks.navigate).toHaveBeenCalledWith('/');
@@ -117,7 +117,7 @@ describe('ConnectPage', () => {
   it('logs in with email when username is empty and toggles password visibility', async () => {
     mocks.login.mockResolvedValueOnce({
       accessToken: 'access-token',
-      refreshToken: 'refresh-token',
+      expiresAt: '2100-01-01T00:00:00.000Z',
     });
     renderPage();
 

--- a/apps/harmonie/src/features/auth/RegisterPage.test.tsx
+++ b/apps/harmonie/src/features/auth/RegisterPage.test.tsx
@@ -105,7 +105,7 @@ describe('RegisterPage', () => {
   it('registers, stores tokens, authenticates, and navigates home', async () => {
     mocks.register.mockResolvedValueOnce({
       accessToken: 'access-token',
-      refreshToken: 'refresh-token',
+      expiresAt: '2100-01-01T00:00:00.000Z',
     });
     renderPage();
 
@@ -127,7 +127,7 @@ describe('RegisterPage', () => {
     );
     expect(mocks.storeTokens).toHaveBeenCalledWith({
       accessToken: 'access-token',
-      refreshToken: 'refresh-token',
+      expiresAt: '2100-01-01T00:00:00.000Z',
     });
     expect(mocks.setIsAuthenticated).toHaveBeenCalledWith(true);
     expect(mocks.navigate).toHaveBeenCalledWith('/');

--- a/apps/harmonie/src/types/auth.ts
+++ b/apps/harmonie/src/types/auth.ts
@@ -15,17 +15,11 @@ export interface RegisterResponse {
   email: string;
   username: string;
   accessToken: string;
-  refreshToken: string;
   expiresAt: string;
-}
-
-export interface RefreshRequest {
-  refreshToken: string;
 }
 
 export interface RefreshResponse {
   accessToken: string;
-  refreshToken: string;
   expiresAt: string;
 }
 
@@ -39,16 +33,10 @@ export interface LoginResponse {
   email: string;
   username: string;
   accessToken: string;
-  refreshToken: string;
   expiresAt: string;
-}
-
-export interface LogoutRequest {
-  refreshToken: string;
 }
 
 export interface TokensPayload {
   accessToken: string;
-  refreshToken: string;
   expiresAt: string;
 }

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -5,7 +5,7 @@
 The authentication system handles user registration, login, and session persistence across page refreshes. It is built around three concerns:
 
 1. **API layer** — pure fetch functions, no side effects
-2. **Token storage** — secure split storage strategy
+2. **Token storage** — access token in memory and refresh token in an HttpOnly cookie
 3. **Auth state** — React context consumed by route guards and pages
 
 ---
@@ -16,7 +16,7 @@ The authentication system handles user registration, login, and session persiste
 apps/harmonie/src/
 ├── api/
 │   ├── auth.ts          # API functions: login, register, refreshTokens
-│   ├── authStorage.ts   # Token read/write (memory + localStorage)
+│   ├── authStorage.ts   # In-memory access token lifecycle
 │   └── errors.ts        # Shared ApiError interface
 ├── features/auth/
 │   ├── AuthContext.tsx  # AuthProvider + useAuth hook
@@ -34,26 +34,26 @@ apps/harmonie/src/
 
 Access tokens are short-lived JWTs. Refresh tokens are long-lived and used to obtain new access tokens silently.
 
-| Token          | Storage            | Rationale                                                                      |
-| -------------- | ------------------ | ------------------------------------------------------------------------------ |
-| `accessToken`  | JS module variable | Never persisted — wiped on page reload; not accessible via XSS from other tabs |
-| `refreshToken` | `localStorage`     | Persisted across page reloads; used on app init to restore the session         |
+| Token          | Storage                          | Rationale                                                                     |
+| -------------- | -------------------------------- | ----------------------------------------------------------------------------- |
+| `accessToken`  | JS module variable               | Never persisted and wiped on page reload                                      |
+| `refreshToken` | Server-managed `HttpOnly` cookie | Persists the session without exposing the long-lived credential to JavaScript |
 
 ### `src/api/authStorage.ts`
 
 ```ts
 let _accessToken: string | null = null;
+let _accessTokenExpiresAt: number | null = null;
 
-export const storeTokens = ({ accessToken, refreshToken }: TokensPayload) => {
+export const storeTokens = ({ accessToken, expiresAt }: TokensPayload) => {
   _accessToken = accessToken;
-  localStorage.setItem('refreshToken', refreshToken);
+  _accessTokenExpiresAt = Date.parse(expiresAt);
 };
 
 export const getAccessToken = () => _accessToken;
-export const getRefreshToken = () => localStorage.getItem('refreshToken');
 export const clearTokens = () => {
   _accessToken = null;
-  localStorage.removeItem('refreshToken');
+  _accessTokenExpiresAt = null;
 };
 ```
 
@@ -77,7 +77,7 @@ VITE_API_BASE_URL=http://localhost:5001/api   # .env
 | `register()`      | POST   | `/auth/register` |
 | `refreshTokens()` | POST   | `/auth/refresh`  |
 
-All functions throw the raw JSON body on non-2xx responses (cast to `ApiError` at the call site).
+All authentication requests use `credentials: 'include'` so the browser can receive and send the refresh cookie. The refresh and logout request bodies contain no credential; an empty `refreshToken` field is temporarily sent for compatibility with the rollout endpoint contract. Functions throw the raw JSON body on non-2xx responses (cast to `ApiError` at the call site).
 
 ### `src/api/errors.ts`
 
@@ -109,7 +109,7 @@ interface AuthContextValue {
 
 #### Session restoration on mount
 
-On first render, `AuthProvider` reads the `refreshToken` from localStorage and silently calls `POST /auth/refresh`. If successful, the new tokens are stored and `isAuthenticated` is set to `true`.
+On first render, `AuthProvider` silently calls `POST /auth/refresh`. The browser attaches the HttpOnly refresh cookie automatically. If successful, the returned access token is stored in memory and `isAuthenticated` is set to `true`.
 
 `isInitializing` stays `true` until this check completes — route guards render nothing while waiting, preventing a flash of the login page for authenticated users.
 
@@ -131,7 +131,7 @@ useEffect(() => {
 
 #### Fatal vs non-fatal refresh errors
 
-Tokens are only cleared when the backend signals an unrecoverable state. Network errors and server errors (5xx) are ignored — the user is simply left unauthenticated without wiping their stored refresh token.
+The in-memory access token is cleared when the backend signals an unrecoverable state. The refresh cookie is rotated or deleted by the backend and cannot be accessed by the client. Network errors and server errors (5xx) leave the user unauthenticated without modifying the cookie.
 
 ```ts
 const FATAL_REFRESH_CODES = new Set([

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -77,7 +77,7 @@ VITE_API_BASE_URL=http://localhost:5001/api   # .env
 | `register()`      | POST   | `/auth/register` |
 | `refreshTokens()` | POST   | `/auth/refresh`  |
 
-All authentication requests use `credentials: 'include'` so the browser can receive and send the refresh cookie. The refresh and logout request bodies contain no credential; an empty `refreshToken` field is temporarily sent for compatibility with the rollout endpoint contract. Functions throw the raw JSON body on non-2xx responses (cast to `ApiError` at the call site).
+All authentication requests use `credentials: 'include'` so the browser can receive and send the refresh cookie. Refresh and logout send no request body because the refresh credential is read exclusively from the HttpOnly cookie. Functions throw the raw JSON body on non-2xx responses (cast to `ApiError` at the call site).
 
 ### `src/api/errors.ts`
 


### PR DESCRIPTION
## Summary

- stop storing or reading refresh tokens in `localStorage`
- keep only the access token and its expiration in memory
- send authentication requests with `credentials: 'include'` so the browser manages the HttpOnly refresh cookie
- send refresh and logout without request bodies
- restore sessions by attempting a cookie-backed refresh on startup
- keep shared HTTP and SignalR refresh deduplication unchanged
- obtain a fresh access token before logout so the authorized logout endpoint can revoke and clear the cookie
- remove refresh tokens left by older client versions
- update authentication tests, types, and architecture documentation

## Backend dependency and rollout

Depends on Harmonie-chat/harmonie-server#435 and Harmonie-chat/harmonie-server#437.

Server PR #437 and this client PR implement the final cookie-only contract and must be deployed together. Users with a client loaded before the coordinated deployment may need to reload and sign in once.

## Validation

- `pnpm format:check`
- `pnpm lint`
- `pnpm test:typecheck`
- 584 app tests passed
- `pnpm build`
- React Doctor: 100/100 on the preceding complete validation

Closes #108