### PR TITLE
fix: restore conversation chat and handle audio output errors

### DIFF
--- a/apps/harmonie/src/features/conversation/view/ConversationView.test.tsx
+++ b/apps/harmonie/src/features/conversation/view/ConversationView.test.tsx
@@ -525,6 +525,31 @@ describe('ConversationView', () => {
     expect(screen.getByRole('heading', { name: 'Research' })).toBeInTheDocument();
   });
 
+  it.each(['Direct', 'Group'] as const)(
+    'switches between chat and an active %s conversation call without leaving',
+    async (type) => {
+      const user = userEvent.setup();
+      mocks.conversation = conversation({ type });
+      mocks.voice.activeConversationId = 'conversation-1';
+
+      render(<ConversationView />);
+
+      expect(screen.getByRole('region', { name: 'conversation call stage' })).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /conversation.call.showChat/ }));
+
+      expect(
+        screen.queryByRole('region', { name: 'conversation call stage' })
+      ).not.toBeInTheDocument();
+      expect(mocks.voice.leaveCall).not.toHaveBeenCalled();
+
+      await user.click(screen.getByRole('button', { name: /conversation.call.show/ }));
+
+      expect(screen.getByRole('region', { name: 'conversation call stage' })).toBeInTheDocument();
+      expect(mocks.voice.leaveCall).not.toHaveBeenCalled();
+    }
+  );
+
   it('joins an existing remote call and leaves an active call', async () => {
     const user = userEvent.setup();
     mocks.voice.getConversationParticipants.mockReturnValue([{ userId: 'user-2' }]);

--- a/apps/harmonie/src/features/conversation/view/ConversationView.tsx
+++ b/apps/harmonie/src/features/conversation/view/ConversationView.tsx
@@ -170,8 +170,6 @@ export const ConversationView = () => {
       : conversationParticipants;
   const callPanelConversationId =
     callPanelState.conversationId === conversationId ? callPanelState.conversationId : null;
-  const storedCallPanelVisible =
-    callPanelState.conversationId === conversationId ? callPanelState.visible : false;
 
   const membersMap = new Map<string, ConversationParticipant>();
   for (const participant of conversationParticipants) {
@@ -201,7 +199,10 @@ export const ConversationView = () => {
     isActiveConversationCall ||
     hasJoinableConversationCall ||
     callPanelConversationId === conversationId;
-  const callPanelVisible = isActiveConversationCall || storedCallPanelVisible;
+  const callPanelVisible =
+    callPanelState.conversationId === conversationId
+      ? callPanelState.visible
+      : isActiveConversationCall;
   const isCallPanelOpen = hasConversationCall && callPanelVisible;
 
   const handleAvatarClick = (participant: ConversationParticipant, rect: DOMRect) => {

--- a/apps/harmonie/src/features/user/audio/AudioOutputContext.test.tsx
+++ b/apps/harmonie/src/features/user/audio/AudioOutputContext.test.tsx
@@ -109,6 +109,40 @@ describe('AudioOutputProvider', () => {
     expect(setSinkId).toHaveBeenLastCalledWith('speaker-1');
   });
 
+  it('falls back to the default output when a stored sink is unavailable', async () => {
+    const sinkError = new DOMException('The object can not be found here.', 'NotFoundError');
+    const setSinkId = vi.fn().mockRejectedValueOnce(sinkError).mockResolvedValue(undefined);
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    localStorage.setItem('harmonie:audioOutputDeviceId', 'missing-speaker');
+    mocks.enumerateDevices.mockResolvedValue([
+      mediaDevice({ deviceId: 'default', label: 'Default speaker' }),
+    ]);
+
+    render(
+      <AudioOutputProvider>
+        <audio
+          data-testid="audio"
+          ref={(element) => {
+            if (element) Object.assign(element, { setSinkId });
+          }}
+        />
+        <OutputConsumer />
+      </AudioOutputProvider>
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    await waitFor(() => expect(screen.getByTestId('selected')).toHaveTextContent('default'));
+    expect(localStorage.getItem('harmonie:audioOutputDeviceId')).toBeNull();
+    expect(setSinkId).toHaveBeenNthCalledWith(1, 'missing-speaker');
+    expect(setSinkId).toHaveBeenNthCalledWith(2, 'default');
+    expect(consoleWarn).toHaveBeenCalledWith(
+      '[AudioOutput] Failed to use output device; falling back to default',
+      { deviceId: 'missing-speaker', error: sinkError }
+    );
+    consoleWarn.mockRestore();
+  });
+
   it('requests audio permission, stops tracks, and refreshes outputs', async () => {
     const stop = vi.fn();
     mocks.enumerateDevices

--- a/apps/harmonie/src/features/user/audio/AudioOutputContext.tsx
+++ b/apps/harmonie/src/features/user/audio/AudioOutputContext.tsx
@@ -21,13 +21,22 @@ const AudioOutputContext = createContext<AudioOutputContextValue | null>(null);
 const STORAGE_KEY = 'harmonie:audioOutputDeviceId';
 const DEFAULT_DEVICE_ID = 'default';
 
-const applyToAllAudioElements = (deviceId: string) => {
-  document.querySelectorAll<HTMLAudioElement>('audio').forEach((el) => {
-    if ('setSinkId' in el) {
-      void (el as HTMLAudioElement & { setSinkId: (id: string) => Promise<void> }).setSinkId(
-        deviceId
-      );
-    }
+type AudioElementWithSinkId = HTMLAudioElement & {
+  setSinkId: (deviceId: string) => Promise<void>;
+};
+
+const setAudioElementSink = (
+  element: HTMLAudioElement,
+  deviceId: string,
+  onError: (error: unknown) => void
+) => {
+  if (!('setSinkId' in element)) return;
+  void (element as AudioElementWithSinkId).setSinkId(deviceId).catch(onError);
+};
+
+const applyToAllAudioElements = (deviceId: string, onError: (error: unknown) => void) => {
+  document.querySelectorAll<HTMLAudioElement>('audio').forEach((element) => {
+    setAudioElementSink(element, deviceId, onError);
   });
 };
 
@@ -91,10 +100,26 @@ export const AudioOutputProvider = ({ children }: { children: ReactNode }) => {
     selectedDeviceIdRef.current = selectedDeviceId;
   }, [selectedDeviceId]);
 
+  const fallbackToDefaultDevice = (failedDeviceId: string, error: unknown) => {
+    console.warn('[AudioOutput] Failed to use output device; falling back to default', {
+      deviceId: failedDeviceId,
+      error,
+    });
+    if (selectedDeviceIdRef.current !== failedDeviceId) return;
+
+    selectedDeviceIdRef.current = DEFAULT_DEVICE_ID;
+    setSelectedDeviceId(DEFAULT_DEVICE_ID);
+    localStorage.removeItem(STORAGE_KEY);
+    applyToAllAudioElements(DEFAULT_DEVICE_ID, (fallbackError) => {
+      console.warn('[AudioOutput] Failed to restore the default output device', fallbackError);
+    });
+  };
+
   const selectDevice = (deviceId: string) => {
+    selectedDeviceIdRef.current = deviceId;
     setSelectedDeviceId(deviceId);
     localStorage.setItem(STORAGE_KEY, deviceId);
-    applyToAllAudioElements(deviceId);
+    applyToAllAudioElements(deviceId, (error) => fallbackToDefaultDevice(deviceId, error));
   };
 
   const requestPermission = async () => {
@@ -117,13 +142,10 @@ export const AudioOutputProvider = ({ children }: { children: ReactNode }) => {
     });
   };
 
-  const applySinkId = (el: HTMLAudioElement) => {
+  const applySinkId = (element: HTMLAudioElement) => {
     const deviceId = selectedDeviceIdRef.current;
-    if ('setSinkId' in el && deviceId !== DEFAULT_DEVICE_ID) {
-      void (el as HTMLAudioElement & { setSinkId: (id: string) => Promise<void> }).setSinkId(
-        deviceId
-      );
-    }
+    if (deviceId === DEFAULT_DEVICE_ID) return;
+    setAudioElementSink(element, deviceId, (error) => fallbackToDefaultDevice(deviceId, error));
   };
 
   return (


### PR DESCRIPTION
## Summary

- let an explicit conversation call-panel choice override the active-call default
- keep the user connected when switching between the call stage and conversation messages
- handle rejected browser `setSinkId()` promises instead of leaving unhandled rejections
- fall back to the system output when a persisted audio device is no longer available
- cover direct/group call switching and unavailable output devices in tests

## Root causes

### Conversation chat

Call-panel visibility was derived with `isActiveConversationCall || storedCallPanelVisible`. During an active call, setting the stored visibility to `false` could therefore never hide the panel.

### Audio output DOMException

The LiveKit `publishing track` entry is a normal informational log. The unhandled exception came from fire-and-forget `HTMLMediaElement.setSinkId()` calls made for connection/disconnection sounds and remote audio. Firefox rejects with `NotFoundError` when the persisted output device is unavailable. Rejections are now handled and the selection falls back to the system default.

## Validation

- `pnpm format:check`
- `pnpm lint` (existing `EmojiInput` hook warning only)
- `pnpm test:typecheck`
- `pnpm test` — 735 tests passed across app and UI
- `pnpm build`

Closes #204
Closes #206