### PR TITLE
feat: add incoming message notification sound

### DIFF
--- a/apps/harmonie/src/features/realtime/MessageActivityContext.test.tsx
+++ b/apps/harmonie/src/features/realtime/MessageActivityContext.test.tsx
@@ -327,6 +327,43 @@ describe('MessageActivityProvider', () => {
     hasFocus.mockRestore();
   });
 
+  it('keeps the sound silent for the active focused channel and conversation', async () => {
+    createConnection();
+    mocks.textChannelMatch = { params: { channelId: 'channel-1' } };
+    mocks.conversationMatch = { params: { conversationId: 'conversation-1' } };
+    const hasFocus = vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+
+    renderProvider();
+
+    await waitFor(() =>
+      expect(mocks.handlers.has(REALTIME_SERVER_EVENTS.messageCreated)).toBe(true)
+    );
+    await waitFor(() =>
+      expect(mocks.handlers.has(REALTIME_SERVER_EVENTS.conversationMessageCreated)).toBe(true)
+    );
+
+    act(() => {
+      mocks.handlers.get(REALTIME_SERVER_EVENTS.messageCreated)?.(channelMessage());
+      mocks.handlers.get(REALTIME_SERVER_EVENTS.conversationMessageCreated)?.(
+        conversationMessage()
+      );
+    });
+
+    expect(mocks.playMessageNotificationSound).not.toHaveBeenCalled();
+
+    act(() => {
+      mocks.handlers.get(REALTIME_SERVER_EVENTS.messageCreated)?.(
+        channelMessage({ channelId: 'channel-2' })
+      );
+      mocks.handlers.get(REALTIME_SERVER_EVENTS.conversationMessageCreated)?.(
+        conversationMessage({ conversationId: 'conversation-2' })
+      );
+    });
+
+    expect(mocks.playMessageNotificationSound).toHaveBeenCalledTimes(2);
+    hasFocus.mockRestore();
+  });
+
   it('does not duplicate browser notifications when web push is enabled', async () => {
     createConnection();
     mocks.pushNotificationStatus = 'enabled';

--- a/apps/harmonie/src/features/realtime/MessageActivityContext.test.tsx
+++ b/apps/harmonie/src/features/realtime/MessageActivityContext.test.tsx
@@ -7,6 +7,7 @@ import { REALTIME_SERVER_EVENTS } from './constants';
 type Handler = (event: Record<string, unknown>) => void;
 
 const mocks = vi.hoisted(() => ({
+  applySinkId: vi.fn(),
   channels: undefined as
     | Array<{ channelId: string; type: string; hasUnread?: boolean }>
     | undefined,
@@ -17,7 +18,9 @@ const mocks = vi.hoisted(() => ({
   conversations: undefined as Array<{ conversationId: string; hasUnread?: boolean }> | undefined,
   guilds: [] as Array<{ guildId: string; hasUnread?: boolean }>,
   handlers: new Map<string, Handler>(),
+  outputMuted: false,
   params: {} as { guildId?: string },
+  playMessageNotificationSound: vi.fn(),
   pushNotificationStatus: 'prompt' as PushNotificationStatus,
   showNotification: vi.fn(),
   textChannelMatch: null as null | { params: { channelId?: string } },
@@ -54,12 +57,23 @@ vi.mock('@/features/realtime/RealtimeContext', () => ({
   useRealtime: () => ({ connection: mocks.connection }),
 }));
 
+vi.mock('@/features/user/audio/AudioOutputContext', () => ({
+  useAudioOutput: () => ({
+    applySinkId: mocks.applySinkId,
+    muted: mocks.outputMuted,
+  }),
+}));
+
 vi.mock('@/features/user/UserContext', () => ({
   useUser: () => ({ user: mocks.user }),
 }));
 
 vi.mock('@/shared/notifications/browserNotification', () => ({
   showBrowserNotification: mocks.showNotification,
+}));
+
+vi.mock('@/shared/notifications/messageNotificationSound', () => ({
+  playMessageNotificationSound: mocks.playMessageNotificationSound,
 }));
 
 vi.mock('@/shared/notifications/PushNotificationContext', () => ({
@@ -139,7 +153,10 @@ describe('MessageActivityProvider', () => {
     mocks.conversations = undefined;
     mocks.guilds = [];
     mocks.handlers.clear();
+    mocks.applySinkId.mockReset();
+    mocks.outputMuted = false;
     mocks.params = {};
+    mocks.playMessageNotificationSound.mockReset();
     mocks.pushNotificationStatus = 'prompt';
     mocks.showNotification.mockReset();
     mocks.textChannelMatch = null;
@@ -253,6 +270,8 @@ describe('MessageActivityProvider', () => {
       })
     );
     expect(screen.getByTestId('total')).toHaveTextContent('4');
+    expect(mocks.playMessageNotificationSound).toHaveBeenCalledTimes(3);
+    expect(mocks.playMessageNotificationSound).toHaveBeenLastCalledWith(mocks.applySinkId, false);
 
     act(() => {
       fireEvent.focus(window);
@@ -303,6 +322,8 @@ describe('MessageActivityProvider', () => {
     });
 
     expect(screen.getByTestId('total')).toHaveTextContent('2');
+    expect(mocks.playMessageNotificationSound).toHaveBeenCalledTimes(2);
+    expect(mocks.playMessageNotificationSound).toHaveBeenLastCalledWith(mocks.applySinkId, false);
     hasFocus.mockRestore();
   });
 

--- a/apps/harmonie/src/features/realtime/MessageActivityContext.test.tsx
+++ b/apps/harmonie/src/features/realtime/MessageActivityContext.test.tsx
@@ -270,7 +270,7 @@ describe('MessageActivityProvider', () => {
       })
     );
     expect(screen.getByTestId('total')).toHaveTextContent('4');
-    expect(mocks.playMessageNotificationSound).toHaveBeenCalledTimes(3);
+    expect(mocks.playMessageNotificationSound).toHaveBeenCalledTimes(2);
     expect(mocks.playMessageNotificationSound).toHaveBeenLastCalledWith(mocks.applySinkId, false);
 
     act(() => {
@@ -322,16 +322,16 @@ describe('MessageActivityProvider', () => {
     });
 
     expect(screen.getByTestId('total')).toHaveTextContent('2');
-    expect(mocks.playMessageNotificationSound).toHaveBeenCalledTimes(2);
+    expect(mocks.playMessageNotificationSound).toHaveBeenCalledTimes(1);
     expect(mocks.playMessageNotificationSound).toHaveBeenLastCalledWith(mocks.applySinkId, false);
     hasFocus.mockRestore();
   });
 
-  it('keeps the sound silent for the active focused channel and conversation', async () => {
+  it('keeps the sound silent for the active channel and conversation', async () => {
     createConnection();
     mocks.textChannelMatch = { params: { channelId: 'channel-1' } };
     mocks.conversationMatch = { params: { conversationId: 'conversation-1' } };
-    const hasFocus = vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    const hasFocus = vi.spyOn(document, 'hasFocus').mockReturnValue(false);
 
     renderProvider();
 

--- a/apps/harmonie/src/features/realtime/MessageActivityContext.tsx
+++ b/apps/harmonie/src/features/realtime/MessageActivityContext.tsx
@@ -244,7 +244,9 @@ export const MessageActivityProvider = ({ children }: { children: ReactNode }) =
 
     const handleMessageCreated = (event: MessageCreatedEvent) => {
       if (event.authorUserId === user?.userId) return;
-      playMessageNotificationSound(applySinkId, outputMuted);
+      if (event.channelId !== activeTextChannelId || !document.hasFocus()) {
+        playMessageNotificationSound(applySinkId, outputMuted);
+      }
 
       const targetUrl = `/guilds/${event.guildId}/channels/${event.channelId}`;
       const senderName =
@@ -310,7 +312,9 @@ export const MessageActivityProvider = ({ children }: { children: ReactNode }) =
 
     const handleConversationMessageCreated = (event: ConversationMessageCreatedEvent) => {
       if (event.authorUserId === user?.userId) return;
-      playMessageNotificationSound(applySinkId, outputMuted);
+      if (event.conversationId !== activeConversationId || !document.hasFocus()) {
+        playMessageNotificationSound(applySinkId, outputMuted);
+      }
 
       const targetUrl = `/conversations/${event.conversationId}`;
       const senderName =

--- a/apps/harmonie/src/features/realtime/MessageActivityContext.tsx
+++ b/apps/harmonie/src/features/realtime/MessageActivityContext.tsx
@@ -244,7 +244,7 @@ export const MessageActivityProvider = ({ children }: { children: ReactNode }) =
 
     const handleMessageCreated = (event: MessageCreatedEvent) => {
       if (event.authorUserId === user?.userId) return;
-      if (event.channelId !== activeTextChannelId || !document.hasFocus()) {
+      if (event.channelId !== activeTextChannelId) {
         playMessageNotificationSound(applySinkId, outputMuted);
       }
 
@@ -312,7 +312,7 @@ export const MessageActivityProvider = ({ children }: { children: ReactNode }) =
 
     const handleConversationMessageCreated = (event: ConversationMessageCreatedEvent) => {
       if (event.authorUserId === user?.userId) return;
-      if (event.conversationId !== activeConversationId || !document.hasFocus()) {
+      if (event.conversationId !== activeConversationId) {
         playMessageNotificationSound(applySinkId, outputMuted);
       }
 

--- a/apps/harmonie/src/features/realtime/MessageActivityContext.tsx
+++ b/apps/harmonie/src/features/realtime/MessageActivityContext.tsx
@@ -4,10 +4,12 @@ import { useChannels } from '@/features/channel/ChannelContext';
 import { useConversations } from '@/features/conversation/ConversationContext';
 import { useGuilds } from '@/features/guild/GuildContext';
 import { useRealtime } from '@/features/realtime/RealtimeContext';
+import { useAudioOutput } from '@/features/user/audio/AudioOutputContext';
 import { useUser } from '@/features/user/UserContext';
 import type { MessageCreatedEvent } from '@/types/channel';
 import type { ConversationMessageCreatedEvent } from '@/types/conversation';
 import { showBrowserNotification } from '@/shared/notifications/browserNotification';
+import { playMessageNotificationSound } from '@/shared/notifications/messageNotificationSound';
 import { usePushNotifications } from '@/shared/notifications/PushNotificationContext';
 import { REALTIME_SERVER_EVENTS } from './constants';
 
@@ -173,6 +175,7 @@ const clearedActivityReducer = (
 export const MessageActivityProvider = ({ children }: { children: ReactNode }) => {
   const { connection } = useRealtime();
   const { status: pushNotificationStatus } = usePushNotifications();
+  const { applySinkId, muted: outputMuted } = useAudioOutput();
   const { user } = useUser();
   const { guilds } = useGuilds();
   const { channels } = useChannels();
@@ -241,6 +244,7 @@ export const MessageActivityProvider = ({ children }: { children: ReactNode }) =
 
     const handleMessageCreated = (event: MessageCreatedEvent) => {
       if (event.authorUserId === user?.userId) return;
+      playMessageNotificationSound(applySinkId, outputMuted);
 
       const targetUrl = `/guilds/${event.guildId}/channels/${event.channelId}`;
       const senderName =
@@ -290,7 +294,15 @@ export const MessageActivityProvider = ({ children }: { children: ReactNode }) =
 
     connection.on(REALTIME_SERVER_EVENTS.messageCreated, handleMessageCreated);
     return () => connection.off(REALTIME_SERVER_EVENTS.messageCreated, handleMessageCreated);
-  }, [connection, currentRouteGuildId, activeTextChannelId, user?.userId, pushNotificationStatus]);
+  }, [
+    connection,
+    currentRouteGuildId,
+    activeTextChannelId,
+    user?.userId,
+    pushNotificationStatus,
+    applySinkId,
+    outputMuted,
+  ]);
 
   // Conversation messages
   useEffect(() => {
@@ -298,6 +310,7 @@ export const MessageActivityProvider = ({ children }: { children: ReactNode }) =
 
     const handleConversationMessageCreated = (event: ConversationMessageCreatedEvent) => {
       if (event.authorUserId === user?.userId) return;
+      playMessageNotificationSound(applySinkId, outputMuted);
 
       const targetUrl = `/conversations/${event.conversationId}`;
       const senderName =
@@ -344,7 +357,14 @@ export const MessageActivityProvider = ({ children }: { children: ReactNode }) =
         REALTIME_SERVER_EVENTS.conversationMessageCreated,
         handleConversationMessageCreated
       );
-  }, [connection, activeConversationId, user?.userId, pushNotificationStatus]);
+  }, [
+    connection,
+    activeConversationId,
+    user?.userId,
+    pushNotificationStatus,
+    applySinkId,
+    outputMuted,
+  ]);
 
   useEffect(() => {
     if (!activeTextChannelId) return;

--- a/apps/harmonie/src/features/user/settings/NotificationsSection.test.tsx
+++ b/apps/harmonie/src/features/user/settings/NotificationsSection.test.tsx
@@ -4,13 +4,27 @@ import { NotificationsSection } from './NotificationsSection';
 import type { PushNotificationStatus } from '@/shared/notifications/webPush';
 
 const mocks = vi.hoisted(() => ({
+  applySinkId: vi.fn(),
   disable: vi.fn(),
   enable: vi.fn(),
+  outputMuted: false,
+  playMessageNotificationSound: vi.fn(),
   status: 'prompt' as PushNotificationStatus,
 }));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/features/user/audio/AudioOutputContext', () => ({
+  useAudioOutput: () => ({
+    applySinkId: mocks.applySinkId,
+    muted: mocks.outputMuted,
+  }),
+}));
+
+vi.mock('@/shared/notifications/messageNotificationSound', () => ({
+  playMessageNotificationSound: mocks.playMessageNotificationSound,
 }));
 
 vi.mock('@/shared/notifications/PushNotificationContext', () => ({
@@ -27,6 +41,9 @@ describe('NotificationsSection', () => {
     mocks.enable.mockReset();
     mocks.enable.mockResolvedValue(undefined);
     mocks.disable.mockResolvedValue(undefined);
+    mocks.applySinkId.mockReset();
+    mocks.outputMuted = false;
+    mocks.playMessageNotificationSound.mockReset();
     mocks.status = 'prompt';
   });
 
@@ -38,6 +55,14 @@ describe('NotificationsSection', () => {
 
     expect(mocks.enable).toHaveBeenCalledOnce();
     expect(mocks.disable).not.toHaveBeenCalled();
+  });
+
+  it('plays a preview through the configured audio output', () => {
+    render(<NotificationsSection />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'notifications.sound.preview' }));
+
+    expect(mocks.playMessageNotificationSound).toHaveBeenCalledWith(mocks.applySinkId, false);
   });
 
   it('disables push notifications from the enabled state', () => {

--- a/apps/harmonie/src/features/user/settings/NotificationsSection.tsx
+++ b/apps/harmonie/src/features/user/settings/NotificationsSection.tsx
@@ -1,11 +1,14 @@
-import { Bell, BellOff } from 'lucide-react';
+import { Bell, BellOff, Volume2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@harmonie/ui';
+import { useAudioOutput } from '@/features/user/audio/AudioOutputContext';
+import { playMessageNotificationSound } from '@/shared/notifications/messageNotificationSound';
 import { usePushNotifications } from '@/shared/notifications/PushNotificationContext';
 
 export const NotificationsSection = () => {
   const { t } = useTranslation();
   const { disable, enable, status } = usePushNotifications();
+  const { applySinkId, muted: outputMuted } = useAudioOutput();
   const isLoading = status === 'syncing';
   const isEnabled = status === 'enabled';
   const canEnable = status === 'disabled' || status === 'prompt' || status === 'error';
@@ -45,7 +48,14 @@ export const NotificationsSection = () => {
         </div>
       </div>
 
-      <div className="flex justify-end">
+      <div className="flex justify-end gap-2">
+        <Button
+          variant="tertiary"
+          onClick={() => playMessageNotificationSound(applySinkId, outputMuted)}
+        >
+          <Volume2 size={16} />
+          {t('notifications.sound.preview')}
+        </Button>
         <Button
           variant={isEnabled ? 'secondary' : 'primary'}
           onClick={handleToggle}

--- a/apps/harmonie/src/i18n/locales/en.ts
+++ b/apps/harmonie/src/i18n/locales/en.ts
@@ -27,6 +27,9 @@ export const en = {
     dateAt: '{{date}} at {{time}}',
   },
   notifications: {
+    sound: {
+      preview: 'Test sound',
+    },
     browser: {
       title: 'New message',
       titleFrom: '{{senderName}} - {{title}}',

--- a/apps/harmonie/src/i18n/locales/fr.ts
+++ b/apps/harmonie/src/i18n/locales/fr.ts
@@ -28,6 +28,9 @@ export const fr = {
     dateAt: '{{date}} à {{time}}',
   },
   notifications: {
+    sound: {
+      preview: 'Tester le son',
+    },
     browser: {
       title: 'Nouveau message',
       titleFrom: '{{senderName}} - {{title}}',

--- a/apps/harmonie/src/shared/notifications/messageNotificationSound.test.ts
+++ b/apps/harmonie/src/shared/notifications/messageNotificationSound.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+class FakeAudio {
+  static instances: FakeAudio[] = [];
+  static playResult: () => Promise<void> = () => Promise.resolve();
+
+  play = vi.fn<() => Promise<void>>(() => FakeAudio.playResult());
+  src: string;
+  volume = 0;
+
+  constructor(src: string) {
+    this.src = src;
+    FakeAudio.instances.push(this);
+  }
+}
+
+const importModule = async () => {
+  vi.resetModules();
+  return import('./messageNotificationSound');
+};
+
+describe('messageNotificationSound', () => {
+  beforeEach(() => {
+    FakeAudio.instances = [];
+    FakeAudio.playResult = () => Promise.resolve();
+    vi.stubGlobal('Audio', FakeAudio);
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => 'blob:message-notification'),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('does not play when output is muted or Audio is unavailable', async () => {
+    const { playMessageNotificationSound } = await importModule();
+    const applySinkId = vi.fn();
+
+    playMessageNotificationSound(applySinkId, true);
+
+    expect(FakeAudio.instances).toHaveLength(0);
+    expect(applySinkId).not.toHaveBeenCalled();
+
+    vi.stubGlobal('Audio', undefined);
+    playMessageNotificationSound(applySinkId, false);
+
+    expect(FakeAudio.instances).toHaveLength(0);
+    expect(applySinkId).not.toHaveBeenCalled();
+  });
+
+  it('generates a cached sound and plays it through the selected output', async () => {
+    const { playMessageNotificationSound } = await importModule();
+    const applySinkId = vi.fn();
+
+    playMessageNotificationSound(applySinkId, false);
+    playMessageNotificationSound(applySinkId, false);
+
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(FakeAudio.instances).toHaveLength(2);
+    expect(FakeAudio.instances[0].src).toBe('blob:message-notification');
+    expect(FakeAudio.instances[0].volume).toBe(0.5);
+    expect(FakeAudio.instances[0].play).toHaveBeenCalledOnce();
+    expect(applySinkId).toHaveBeenCalledTimes(2);
+  });
+
+  it('logs playback failures without throwing', async () => {
+    const { playMessageNotificationSound } = await importModule();
+    const error = new Error('blocked');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    FakeAudio.playResult = () => Promise.reject(error);
+
+    playMessageNotificationSound(vi.fn(), false);
+    await Promise.resolve();
+
+    expect(consoleError).toHaveBeenCalledWith(
+      '[Notifications] Failed to play message sound',
+      error
+    );
+  });
+});

--- a/apps/harmonie/src/shared/notifications/messageNotificationSound.ts
+++ b/apps/harmonie/src/shared/notifications/messageNotificationSound.ts
@@ -1,0 +1,76 @@
+type ApplySinkId = (element: HTMLAudioElement) => void;
+
+const SAMPLE_RATE = 44100;
+const DURATION_SECONDS = 0.36;
+const VOLUME = 0.5;
+const NOTE_STARTS = [0, 0.09];
+const NOTE_FREQUENCIES = [185, 277.18];
+const NOTE_GAINS = [0.48, 0.58];
+let cachedSoundUrl: string | null = null;
+
+const writeString = (view: DataView, offset: number, value: string) => {
+  for (let i = 0; i < value.length; i += 1) {
+    view.setUint8(offset + i, value.charCodeAt(i));
+  }
+};
+
+const createMessageNotificationSoundUrl = () => {
+  const sampleCount = Math.floor(SAMPLE_RATE * DURATION_SECONDS);
+  const bytesPerSample = 2;
+  const dataSize = sampleCount * bytesPerSample;
+  const buffer = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(buffer);
+
+  writeString(view, 0, 'RIFF');
+  view.setUint32(4, 36 + dataSize, true);
+  writeString(view, 8, 'WAVE');
+  writeString(view, 12, 'fmt ');
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, SAMPLE_RATE, true);
+  view.setUint32(28, SAMPLE_RATE * bytesPerSample, true);
+  view.setUint16(32, bytesPerSample, true);
+  view.setUint16(34, 8 * bytesPerSample, true);
+  writeString(view, 36, 'data');
+  view.setUint32(40, dataSize, true);
+
+  for (let i = 0; i < sampleCount; i += 1) {
+    const time = i / SAMPLE_RATE;
+    let sample = 0;
+
+    for (let noteIndex = 0; noteIndex < NOTE_STARTS.length; noteIndex += 1) {
+      const noteTime = time - NOTE_STARTS[noteIndex];
+      if (noteTime < 0) continue;
+
+      const frequency = NOTE_FREQUENCIES[noteIndex];
+      const attack = Math.min(1, noteTime / 0.006);
+      const decay = Math.exp(-13 * noteTime);
+      const envelope = attack * decay * NOTE_GAINS[noteIndex];
+      const fundamental = Math.sin(2 * Math.PI * frequency * noteTime);
+      const warmth = Math.sin(2 * Math.PI * frequency * 0.5 * noteTime) * 0.08;
+      const shimmer = Math.sin(2 * Math.PI * frequency * 2 * noteTime) * 0.14;
+
+      sample += (fundamental + warmth + shimmer) * envelope;
+    }
+
+    const normalizedSample = Math.max(-1, Math.min(1, sample));
+    view.setInt16(44 + i * bytesPerSample, normalizedSample * 0x7fff, true);
+  }
+
+  return URL.createObjectURL(new Blob([buffer], { type: 'audio/wav' }));
+};
+
+export const playMessageNotificationSound = (applySinkId: ApplySinkId, muted: boolean) => {
+  if (muted || typeof Audio === 'undefined') return;
+
+  cachedSoundUrl ??= createMessageNotificationSoundUrl();
+
+  const audioElement = new Audio(cachedSoundUrl);
+  audioElement.volume = VOLUME;
+  applySinkId(audioElement);
+
+  void audioElement.play().catch((error) => {
+    console.error('[Notifications] Failed to play message sound', error);
+  });
+};


### PR DESCRIPTION
## Summary

- generate the approved incoming-message chime in code without a binary audio asset
- play it for messages received from other users in guild text channels and direct/group conversations
- keep the currently open channel or conversation silent to avoid repetitive sounds while reading
- route playback through the configured audio output and respect global output mute
- cache the generated WAV URL and catch playback failures
- add a localized Test sound action under notification settings
- cover sound generation, playback, mute behavior, failures, preview, and both realtime message event types

## Sound

The approved two-note version uses 185 Hz and 277.18 Hz with a short 360 ms envelope.

## Validation

- `pnpm format:check`
- `pnpm lint` (existing `EmojiInput` hook warning only)
- `pnpm test:typecheck`
- `pnpm test` — 739 tests passed across app and UI before the focused-channel refinement
- focused activity tests — 8 passed, including open channel/conversation silence even when browser focus changes
- `pnpm build`

Closes #207