### PR TITLE
feat: show unread conversation shortcuts

### DIFF
--- a/apps/harmonie/src/features/guild/GuildSidebar.test.tsx
+++ b/apps/harmonie/src/features/guild/GuildSidebar.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Conversation } from '@/types/conversation';
 import type { Guild } from '@/types/guild';
 import { GuildSidebar } from './GuildSidebar';
 
@@ -14,7 +15,12 @@ const guildMocks = vi.hoisted(() => ({
   fetchGuilds: vi.fn(),
   guilds: [] as Guild[],
   hasAnyUnreadConversation: vi.fn(),
+  hasUnreadConversation: vi.fn(),
   hasUnreadGuild: vi.fn(),
+}));
+
+const conversationMocks = vi.hoisted(() => ({
+  conversations: [] as Conversation[],
 }));
 
 vi.mock('react-i18next', () => ({
@@ -93,8 +99,23 @@ vi.mock('@/shared/hooks/useFileBlobUrl', () => ({
 vi.mock('@/features/realtime/MessageActivityContext', () => ({
   useMessageActivity: () => ({
     hasAnyUnreadConversation: guildMocks.hasAnyUnreadConversation,
+    hasUnreadConversation: guildMocks.hasUnreadConversation,
     hasUnreadGuild: guildMocks.hasUnreadGuild,
   }),
+}));
+
+vi.mock('@/features/conversation/ConversationContext', () => ({
+  useConversations: () => ({ conversations: conversationMocks.conversations }),
+}));
+
+vi.mock('@/features/conversation/avatar/ConversationAvatar', () => ({
+  ConversationAvatar: ({ label }: { label: string }) => (
+    <span data-testid={`conversation-avatar-${label}`} />
+  ),
+}));
+
+vi.mock('@/features/user/UserContext', () => ({
+  useUser: () => ({ user: { userId: 'user-current' } }),
 }));
 
 vi.mock('./GuildContext', () => ({
@@ -163,6 +184,39 @@ vi.mock('@/features/guild/settings/GuildSettingsModal', () => ({
   ),
 }));
 
+const conversations: Conversation[] = [
+  {
+    conversationId: 'conversation-direct',
+    type: 'Direct',
+    name: null,
+    participants: [
+      { userId: 'user-current', username: 'Current user' },
+      { userId: 'user-alice', username: 'alice', displayName: 'Alice' },
+    ],
+    createdAtUtc: '2026-01-01T00:00:00Z',
+  },
+  {
+    conversationId: 'conversation-group',
+    type: 'Group',
+    name: 'Project group',
+    participants: [
+      { userId: 'user-current', username: 'Current user' },
+      { userId: 'user-bob', username: 'bob', displayName: 'Bob' },
+    ],
+    createdAtUtc: '2026-01-02T00:00:00Z',
+  },
+  {
+    conversationId: 'conversation-read',
+    type: 'Direct',
+    name: null,
+    participants: [
+      { userId: 'user-current', username: 'Current user' },
+      { userId: 'user-carol', username: 'carol', displayName: 'Carol' },
+    ],
+    createdAtUtc: '2026-01-03T00:00:00Z',
+  },
+];
+
 const guilds: Guild[] = [
   {
     guildId: 'guild-admin',
@@ -190,8 +244,34 @@ describe('GuildSidebar', () => {
     routerMocks.locationPathname = '/guilds/guild-admin';
     routerMocks.params = { guildId: 'guild-admin' };
     guildMocks.guilds = guilds;
+    conversationMocks.conversations = [];
     guildMocks.hasAnyUnreadConversation.mockReturnValue(true);
+    guildMocks.hasUnreadConversation.mockReturnValue(false);
     guildMocks.hasUnreadGuild.mockImplementation((guildId: string) => guildId === 'guild-owner');
+  });
+
+  it('renders unread conversation shortcuts and navigates directly to a conversation', () => {
+    conversationMocks.conversations = conversations;
+    guildMocks.hasUnreadConversation.mockImplementation(
+      (conversationId: string) => conversationId !== 'conversation-read'
+    );
+
+    const { rerender } = render(<GuildSidebar />);
+
+    expect(screen.getByTestId('conversation-avatar-Alice')).toBeInTheDocument();
+    expect(screen.getByTestId('conversation-avatar-Project group')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Carol' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Alice' }));
+    expect(routerMocks.navigate).toHaveBeenCalledWith('/conversations/conversation-direct');
+
+    guildMocks.hasUnreadConversation.mockImplementation(
+      (conversationId: string) => conversationId === 'conversation-group'
+    );
+    rerender(<GuildSidebar />);
+
+    expect(screen.queryByRole('button', { name: 'Alice' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Project group' })).toBeInTheDocument();
   });
 
   it('renders guild shortcuts and navigates to conversations or a guild', () => {

--- a/apps/harmonie/src/features/guild/GuildSidebar.tsx
+++ b/apps/harmonie/src/features/guild/GuildSidebar.tsx
@@ -3,14 +3,54 @@ import { DoorOpen, House, Mailbox, Pencil, Plus, ShieldBan, Trash2 } from 'lucid
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { ContextMenu, GuildAvatar, Tooltip } from '@harmonie/ui';
+import { useConversations } from '@/features/conversation/ConversationContext';
+import { ConversationAvatar } from '@/features/conversation/avatar/ConversationAvatar';
+import { getConversationLabel } from '@/features/conversation/conversationUtils';
 import { useMessageActivity } from '@/features/realtime/MessageActivityContext';
+import { useUser } from '@/features/user/UserContext';
 import { useFileBlobUrl } from '@/shared/hooks/useFileBlobUrl';
 import { useGuilds } from './GuildContext';
 import { GuildCreateOrJoinModal } from '@/features/guild/join/GuildCreateOrJoinModal';
 import { useGuildPermissions } from '@/features/guild/useGuildPermissions';
+import type { Conversation } from '@/types/conversation';
 import type { Guild } from '@/types/guild';
 import { GuildSettingsModal } from '@/features/guild/settings/GuildSettingsModal';
 import { AdminSectionMenu } from '@/features/guild/settings/adminSection';
+
+const UnreadConversationShortcut = ({
+  conversation,
+  currentUserId,
+  onClick,
+}: {
+  conversation: Conversation;
+  currentUserId?: string;
+  onClick: () => void;
+}) => {
+  const label = getConversationLabel(conversation, currentUserId);
+
+  return (
+    <div className="relative">
+      <Tooltip content={label} side="right">
+        <button
+          type="button"
+          onClick={onClick}
+          aria-label={label}
+          className="size-10 rounded-xl flex items-center justify-center shrink-0 bg-surface-2 cursor-pointer transform-gpu transition-transform duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] hover:bg-surface-3 hover:scale-[1.1] active:scale-[0.97]"
+        >
+          <ConversationAvatar
+            conversation={conversation}
+            label={label}
+            currentUserId={currentUserId}
+          />
+        </button>
+      </Tooltip>
+      <span
+        aria-hidden="true"
+        className="absolute top-1 right-0 size-2.5 rounded-full bg-primary ring-2 ring-background"
+      />
+    </div>
+  );
+};
 
 const GuildSidebarItem = ({
   guild,
@@ -96,7 +136,12 @@ export const GuildSidebar = () => {
   const location = useLocation();
   const isConversationsRoute = location.pathname.startsWith('/conversations');
   const { guilds, fetchGuilds } = useGuilds();
-  const { hasUnreadGuild, hasAnyUnreadConversation } = useMessageActivity();
+  const { conversations } = useConversations();
+  const { user } = useUser();
+  const { hasUnreadGuild, hasUnreadConversation, hasAnyUnreadConversation } = useMessageActivity();
+  const unreadConversations =
+    conversations?.filter((conversation) => hasUnreadConversation(conversation.conversationId)) ??
+    [];
   const [state, dispatch] = useReducer(guildSidebarReducer, guildSidebarInitialState);
   const { addMenu, createOrJoinMode, contextMenu, editSection, editGuild } = state;
 
@@ -186,6 +231,14 @@ export const GuildSidebar = () => {
               <span className="absolute top-1 right-0 size-2.5 rounded-full bg-primary ring-2 ring-background" />
             )}
           </div>
+          {unreadConversations.map((conversation) => (
+            <UnreadConversationShortcut
+              key={conversation.conversationId}
+              conversation={conversation}
+              currentUserId={user?.userId}
+              onClick={() => navigate(`/conversations/${conversation.conversationId}`)}
+            />
+          ))}
           <hr className="w-8 border-t border-border-2 my-0" />
           {/* List of guilds */}
           {guilds.map((guild) => {


### PR DESCRIPTION
## Summary

- display unread direct and group conversation shortcuts below the Conversations home button
- reuse existing conversation avatars and labels
- navigate directly to the selected conversation
- remove shortcuts when their unread state clears
- preserve the aggregate Home notification indicator and shared sidebar scrolling

## Validation

- `pnpm --filter @harmonie/app test`
- `pnpm --filter @harmonie/app test:coverage` (93.83% statements, 80.17% branches)
- `pnpm --filter @harmonie/app test:typecheck`
- `pnpm --filter @harmonie/app lint`
- `pnpm --filter @harmonie/app build`
- `pnpm exec prettier --check apps/harmonie/src/features/guild/GuildSidebar.tsx apps/harmonie/src/features/guild/GuildSidebar.test.tsx`

Fixes #211
